### PR TITLE
feat(alt-backtick): add visual overlay switcher for same-group windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 ﻿cmake-build-*
-.idea
+.idea/
+build/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,7 +74,9 @@ add_executable(Win_Switcher src/main.cpp
         header/UpdateDialog.h
         ui/UpdateDialog.ui
         src/utils/ScheduledTask.cpp
-        header/utils/ScheduledTask.h)
+        header/utils/ScheduledTask.h
+        src/GroupSwitcherWidget.cpp
+        header/GroupSwitcherWidget.h)
 target_link_libraries(Win_Switcher
         Qt::Core
         Qt::Gui
@@ -108,6 +110,21 @@ target_compile_definitions(${PROJECT_NAME} PRIVATE
 if (MSVC)
     target_compile_options(${PROJECT_NAME} PRIVATE "/utf-8")
 endif ()
+
+# 构建后将 README.md 及其引用的 img/ 资源复制到产物目录，
+# 使发布包中的 README 能离线渲染图片（与仓库内相对路径保持一致，GitHub 页面也能正常显示）
+add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different
+        "${CMAKE_CURRENT_SOURCE_DIR}/README.md"
+        "$<TARGET_FILE_DIR:${PROJECT_NAME}>/README.md"
+        COMMAND ${CMAKE_COMMAND} -E copy_directory_if_different
+        "${CMAKE_CURRENT_SOURCE_DIR}/img"
+        "$<TARGET_FILE_DIR:${PROJECT_NAME}>/img"
+        COMMAND ${CMAKE_COMMAND} -E copy_directory_if_different
+        "${CMAKE_CURRENT_SOURCE_DIR}/doc"
+        "$<TARGET_FILE_DIR:${PROJECT_NAME}>/doc"
+        COMMENT "Copying README.md, img/ and doc/ to $<TARGET_FILE_DIR:${PROJECT_NAME}>"
+)
 
 option(ALTTABER_AUTO_DEPLOY_QT "Automatically run windeployqt after building on Windows" ON)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,10 +94,10 @@ target_link_libraries(${PROJECT_NAME}
 # 必须放在find_package之后，否则`Qt6Gui_PRIVATE_INCLUDE_DIRS`变量未定义
 # target_include_directories(${PROJECT_NAME} PRIVATE ${Qt6Gui_PRIVATE_INCLUDE_DIRS} ${Qt6Core_PRIVATE_INCLUDE_DIRS})
 
-set_target_properties(${PROJECT_NAME} PROPERTIES OUTPUT_NAME "AltTaber") # 设置输出文件名
-if (CMAKE_BUILD_TYPE MATCHES "Release")
-    set_target_properties(${PROJECT_NAME} PROPERTIES WIN32_EXECUTABLE true) # 设置为窗口应用程序, 无控制台，同时会导致Clion无法捕获输出
-endif ()
+set_target_properties(${PROJECT_NAME} PROPERTIES
+        OUTPUT_NAME "AltTaber" # 设置输出文件名
+        WIN32_EXECUTABLE $<CONFIG:Release> # Visual Studio 等多配置生成器下也能正确区分 Release / Debug
+)
 
 target_compile_definitions(${PROJECT_NAME} PRIVATE
         QT_DEPRECATED_WARNINGS
@@ -107,4 +107,33 @@ target_compile_definitions(${PROJECT_NAME} PRIVATE
 
 if (MSVC)
     target_compile_options(${PROJECT_NAME} PRIVATE "/utf-8")
+endif ()
+
+option(ALTTABER_AUTO_DEPLOY_QT "Automatically run windeployqt after building on Windows" ON)
+
+if (WIN32 AND ALTTABER_AUTO_DEPLOY_QT)
+    get_target_property(QT_QMAKE_EXECUTABLE Qt6::qmake IMPORTED_LOCATION)
+    if (QT_QMAKE_EXECUTABLE)
+        get_filename_component(QT_BIN_DIR "${QT_QMAKE_EXECUTABLE}" DIRECTORY)
+    endif ()
+
+    find_program(WINDEPLOYQT_EXECUTABLE
+            NAMES windeployqt windeployqt.exe
+            HINTS "${QT_BIN_DIR}"
+    )
+
+    if (WINDEPLOYQT_EXECUTABLE)
+        add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
+                COMMAND "${WINDEPLOYQT_EXECUTABLE}"
+                "$<IF:$<CONFIG:Debug>,--debug,--release>"
+                --dir "$<TARGET_FILE_DIR:${PROJECT_NAME}>"
+                --no-translations
+                --verbose 0
+                "$<TARGET_FILE:${PROJECT_NAME}>"
+                COMMENT "Deploying Qt runtime for $<TARGET_FILE_NAME:${PROJECT_NAME}>"
+                VERBATIM
+        )
+    else ()
+        message(WARNING "ALTTABER_AUTO_DEPLOY_QT is ON, but windeployqt was not found. Qt DLLs will need to be deployed manually.")
+    endif ()
 endif ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)
 set(CMAKE_AUTOUIC ON)
-set(CMAKE_PREFIX_PATH "D:/Qt/6.8.1/msvc2022_64/lib/cmake")
+set(CMAKE_PREFIX_PATH "C:/Qt/6.11.0/msvc2022_64/lib/cmake")
 list(APPEND CMAKE_AUTOUIC_SEARCH_PATHS ui) # 如果.ui文件不在.cpp同一目录下，需要添加搜索路径
 
 # 设置版本信息变量
@@ -36,6 +36,8 @@ find_package(Qt6 COMPONENTS
         Widgets
         Xml
         Network
+        CorePrivate
+        GuiPrivate
         REQUIRED)
 
 add_executable(Win_Switcher src/main.cpp
@@ -79,15 +81,18 @@ target_link_libraries(Win_Switcher
         Qt::Widgets
         Qt::Xml
         Qt::Network
+        Qt6::CorePrivate
+        Qt6::GuiPrivate 
 )
 
 target_link_libraries(${PROJECT_NAME}
         Dwmapi
+        runtimeobject
 )
 
 # 启用`gui_private`模块
 # 必须放在find_package之后，否则`Qt6Gui_PRIVATE_INCLUDE_DIRS`变量未定义
-target_include_directories(${PROJECT_NAME} PRIVATE ${Qt6Gui_PRIVATE_INCLUDE_DIRS})
+# target_include_directories(${PROJECT_NAME} PRIVATE ${Qt6Gui_PRIVATE_INCLUDE_DIRS} ${Qt6Core_PRIVATE_INCLUDE_DIRS})
 
 set_target_properties(${PROJECT_NAME} PROPERTIES OUTPUT_NAME "AltTaber") # 设置输出文件名
 if (CMAKE_BUILD_TYPE MATCHES "Release")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)
 set(CMAKE_AUTOUIC ON)
-set(CMAKE_PREFIX_PATH "D:/Qt/6.8.1/msvc2022_64/lib/cmake")
+set(CMAKE_PREFIX_PATH "C:/Qt/6.11.0/msvc2022_64/lib/cmake")
 list(APPEND CMAKE_AUTOUIC_SEARCH_PATHS ui) # 如果.ui文件不在.cpp同一目录下，需要添加搜索路径
 
 # 设置版本信息变量
@@ -36,6 +36,8 @@ find_package(Qt6 COMPONENTS
         Widgets
         Xml
         Network
+        CorePrivate
+        GuiPrivate
         REQUIRED)
 
 add_executable(Win_Switcher src/main.cpp
@@ -79,20 +81,23 @@ target_link_libraries(Win_Switcher
         Qt::Widgets
         Qt::Xml
         Qt::Network
+        Qt6::CorePrivate
+        Qt6::GuiPrivate 
 )
 
 target_link_libraries(${PROJECT_NAME}
         Dwmapi
+        runtimeobject
 )
 
 # 启用`gui_private`模块
 # 必须放在find_package之后，否则`Qt6Gui_PRIVATE_INCLUDE_DIRS`变量未定义
-target_include_directories(${PROJECT_NAME} PRIVATE ${Qt6Gui_PRIVATE_INCLUDE_DIRS})
+# target_include_directories(${PROJECT_NAME} PRIVATE ${Qt6Gui_PRIVATE_INCLUDE_DIRS} ${Qt6Core_PRIVATE_INCLUDE_DIRS})
 
-set_target_properties(${PROJECT_NAME} PROPERTIES OUTPUT_NAME "AltTaber") # 设置输出文件名
-if (CMAKE_BUILD_TYPE MATCHES "Release")
-    set_target_properties(${PROJECT_NAME} PROPERTIES WIN32_EXECUTABLE true) # 设置为窗口应用程序, 无控制台，同时会导致Clion无法捕获输出
-endif ()
+set_target_properties(${PROJECT_NAME} PROPERTIES
+        OUTPUT_NAME "AltTaber" # 设置输出文件名
+        WIN32_EXECUTABLE $<CONFIG:Release> # Visual Studio 等多配置生成器下也能正确区分 Release / Debug
+)
 
 target_compile_definitions(${PROJECT_NAME} PRIVATE
         QT_DEPRECATED_WARNINGS
@@ -102,4 +107,42 @@ target_compile_definitions(${PROJECT_NAME} PRIVATE
 
 if (MSVC)
     target_compile_options(${PROJECT_NAME} PRIVATE "/utf-8")
+endif ()
+
+option(ALTTABER_AUTO_DEPLOY_QT "Automatically run windeployqt after building on Windows" ON)
+
+if (WIN32 AND ALTTABER_AUTO_DEPLOY_QT)
+    add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
+            COMMAND ${CMAKE_COMMAND} -E copy_if_different
+            $<TARGET_RUNTIME_DLLS:${PROJECT_NAME}>
+            $<TARGET_FILE_DIR:${PROJECT_NAME}>
+            COMMAND_EXPAND_LISTS
+            COMMENT "Copying runtime DLLs for $<TARGET_FILE_NAME:${PROJECT_NAME}>"
+    )
+
+    get_target_property(QT_QMAKE_EXECUTABLE Qt6::qmake IMPORTED_LOCATION)
+    if (QT_QMAKE_EXECUTABLE)
+        get_filename_component(QT_BIN_DIR "${QT_QMAKE_EXECUTABLE}" DIRECTORY)
+    endif ()
+
+    find_program(WINDEPLOYQT_EXECUTABLE
+            NAMES windeployqt windeployqt.exe
+            HINTS "${QT_BIN_DIR}"
+    )
+
+    if (WINDEPLOYQT_EXECUTABLE)
+        add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
+                COMMAND "${WINDEPLOYQT_EXECUTABLE}"
+                "$<IF:$<CONFIG:Debug>,--debug,--release>"
+                --no-compiler-runtime
+                --dir "$<TARGET_FILE_DIR:${PROJECT_NAME}>"
+                --no-translations
+                --verbose 0
+                "$<TARGET_FILE:${PROJECT_NAME}>"
+                COMMENT "Deploying Qt runtime for $<TARGET_FILE_NAME:${PROJECT_NAME}>"
+                VERBATIM
+        )
+    else ()
+        message(WARNING "ALTTABER_AUTO_DEPLOY_QT is ON, but windeployqt was not found. Qt DLLs will need to be deployed manually.")
+    endif ()
 endif ()

--- a/README.md
+++ b/README.md
@@ -1,118 +1,256 @@
 ﻿# AltTaber
 
-![GitHub release (latest by date)](https://img.shields.io/github/v/release/MrBeanCpp/AltTaber)
-![Github Release Downloads](https://img.shields.io/github/downloads/MrBeanCpp/AltTaber/total)
-![Language](https://img.shields.io/badge/language-C++-239120)
-![OS](https://img.shields.io/badge/OS-Windows-0078D4)
+![Language](https://img.shields.io/badge/language-C++20-239120)
+![Framework](https://img.shields.io/badge/framework-Qt%206-41cd52)
+![OS](https://img.shields.io/badge/OS-Windows%2010%2F11-0078D4)
+![License](https://img.shields.io/badge/license-MIT-blue)
 
-一款 MacOS 风格的 `Alt-Tab` 窗口/应用切换器，专为`Windows`💻️开发:
+> A macOS-style `Alt-Tab` window/application switcher built for **Windows** 💻.
+
+🔗 **GitHub**: <https://github.com/tutumumu777/AltTaber>
+🌐 **Languages**: **English** · [简体中文](doc/README.zh-CN.md)
+📚 **Docs**: [`doc/README.en.md`](doc/README.en.md) · [`doc/README.zh-CN.md`](doc/README.zh-CN.md)
 
 ![ui](img/ui.png)
 
-## ⚡主要功能
+---
 
-### 1. ``` Alt+Tab ```: 在应用程序📦间切换
+## 📑 Table of Contents
 
-- 按住`Shift`反向切换
-- 松开`Alt`后，切换到指定应用
-- **最近使用**的应用优先排在左侧
+- [⚡ Features](#-features)
+- [⌨️ Keyboard Shortcuts](#️-keyboard-shortcuts)
+- [🌟 Visual Highlights](#-visual-highlights)
+- [🖱 System Tray](#-system-tray)
+- [⚙ Configuration](#-configuration)
+- [🔑 Runtime & Permissions](#-runtime--permissions)
+- [🔧 Building](#-building)
+- [🧐 Credits](#-credits)
+
+---
+
+## ⚡ Features
+
+### 1. `Alt+Tab` — Switch Across Applications
+
+- Horizontal icon grid; **most recently used (MRU)** apps come first
+- Hold `Shift` to reverse
+- Releasing `Alt` switches to the most recently active window of the selected app
+- A **badge** at the top-right of each icon shows the number of open windows for that app
 
 ![switch apps](img/Alt_tab.gif)
 
-### 2. ``` Alt+` ```: 在同一应用的不同**窗口**🪟间轮换
+### 2. ``Alt+` `` — Switch Between Windows of the Same App
 
-- 按住`Shift`反向切换
-- **最近活动**的窗口优先访问
-- 可用于隐藏`AltTaber`窗口（若可见）
+- **New vertical layout**: a large app icon at the top, list of window titles below
+- Hold `Shift` to reverse
+- Most recently active window first
+- A thin scrollbar appears automatically when items exceed the threshold (default `15`, configurable)
 
-![switch windows](img/Alt_`.gif)
+![switch windows](img/Alt_%60.gif)
 
-### 3. `Alt+Tab` 呼出窗口切换器后，可用`🖱️鼠标滚轮`切换指定应用的窗口
+> **Mode mutual switching** (v0.5+): pressing ``Alt+` `` while the Alt+Tab popup is shown switches you into the same-app window list (based on the currently selected app); and vice versa. No need to release `Alt` in between.
 
-- 向上滚轮：切换到上一个窗口（不改变焦点）
-- 向下滚轮：**最小化**上一个窗口
+### 3. Mouse Wheel on the Switcher — Switch / Minimize Windows
 
-#### ⌨️支持键盘操作
+With the `Alt+Tab` popup visible, hover over an app icon and scroll:
 
-- 方向键:
-    - ⬅️ ➡️: 切换当前选中的应用
-    - ⬆️ ⬇️: 映射到滚轮上下，切换/最小化窗口
-- 支持`Vim`风格的快捷键:
-    - `h` `l`: 切换当前选中的应用
-    - `j` `k`: 切换/最小化窗口
+- **Wheel up** ⬆️: bring the next window of that app to front (without taking focus)
+- **Wheel down** ⬇️: **minimize** the current window
 
 ![wheel](img/Alt_Wheel.gif)
 
-### 4. 在`任务栏`的应用图标上使用`🖱️鼠标滚轮`切换窗口. 🚧`[Beta]`🚧
+### 4. Wheel on Taskbar Icons 🚧 `Beta`
 
 > [!CAUTION]
-> 实验性功能，仍在测试中，可能会遇到一些问题
->
-> 例如：对某些应用程序失效
+> Experimental. May not work for some applications.
 
-- 向上滚轮：切换到上一个窗口
-- 向下滚轮：**最小化**上一个窗口
+Just scroll the wheel on a taskbar icon to switch windows of that app:
+
+- **Wheel up** ⬆️: switch to the previous window
+- **Wheel down** ⬇️: minimize the current window
 
 ![taskbar wheel](img/Taskbar_Wheel.gif)
 
-## 🌟更多特色
+### 5. Keyboard Operations (When the Switcher Is Visible)
 
-- 窗口背景**毛玻璃**特效
-    - ![bg blur](img/bg-blur.png)
-- 适配`Win11`的窗口圆角效果
-- 在应用图标右上角显示**窗口数量**（Badge）
-    - ![app badge](img/app%20badge.png)
-- 在`QQ`🐧图标右下角显示当前聊天好友`头像`
-    - ![qq avatar](img/app%20qq%20avatar.png)
-- 支持在更高权限窗口上使用`Alt+Tab`切换
-- 更合理的窗口过滤规则
-- 支持高DPI缩放、多屏幕显示
-- 可切换显示屏幕：跟随鼠标所在屏幕 / 主屏幕
+- Arrow keys:
+  - ⬅️ ➡️: select previous / next app
+  - ⬆️ ⬇️: mapped to wheel up / down (switch / minimize windows)
+- Vim-style:
+  - `h` / `l`: select previous / next app
+  - `j` / `k`: switch / minimize windows
+- `Tab` / `Shift+Tab`: equivalent to ⬅️ / ➡️
 
-## ✒️TO-DO
+---
 
-- [x] 单例模式
-- [ ] 自适应app太多的情况
-- [x] 支持配置开启启动项
-- [x] 支持管理管理员权限窗口
-- [ ] 自定义配置
-- [ ] ...
+## ⌨️ Keyboard Shortcuts
 
-## 🔑以管理员身份运行（可选）
+| Shortcut | Action |
+|:---:|:---|
+| `Alt+Tab` | Show the cross-app switcher; keep pressing `Tab` to cycle |
+| `Alt+Shift+Tab` | Reverse cycle |
+| ``Alt+` `` | Show the same-app window switcher |
+| ``Alt+Shift+` `` | Reverse cycle |
+| `←` `→` / `h` `l` | Select prev / next app within the switcher |
+| `↑` `↓` / `j` `k` | Switch / minimize windows (same as wheel) |
+| Release `Alt` | Commit selection and switch to the target window |
+| Wheel on a switcher icon | Switch / minimize windows of that app |
+| Wheel on a taskbar icon | Same (Beta) |
 
-`AltTaber`可以在普通用户权限下运行，但有一定的局限性：
+---
 
-只有以**管理员身份**运行，`AltTaber`才能管理拥有更高权限的窗口，例如：
+## 🌟 Visual Highlights
 
-- 系统窗口：如任务管理器
-- 管理员权限窗口：如游戏加速器
+- **Acrylic / frosted-glass** background blur
+  ![bg blur](img/bg-blur.png)
+- Adapts to **Win11 rounded corners**
+- **Window-count badge** at the top-right of each app icon
+  ![app badge](img/app%20badge.png)
+- Custom **QQ chat-partner avatar** overlaid on the QQ icon
+  ![qq avatar](img/app%20qq%20avatar.png)
+- Full **HiDPI / multi-monitor** support
+- Configurable display monitor: **mouse-tracked** / **primary** (toggle via tray menu)
+- Every visual property (icon size, font, color, padding, radius, scroll threshold...) is configurable through INI with hot-reload
 
-### 开机自启动
+---
 
-在托盘菜单中点击`Start with Windows`即可设置开机自启动，自启动时的权限与当前程序权限一致
+## 🖱 System Tray
 
-- 若当前程序以**管理员**权限运行，则开机自启动也会以管理员权限运行（计划任务）🔑
-- 若当前程序以**普通**权限运行，则开机自启动也会以普通权限运行（注册表）
+Right-click the tray icon to access:
 
-## ⚙配置
+| Menu | Description |
+|:---|:---|
+| **Check for Updates** | Check the latest GitHub release |
+| **Settings** | Open `config.ini` in `notepad.exe`; **auto-reload after closing notepad** |
+| **Start with Windows** | Toggle auto-start; user-mode → registry, admin-mode → scheduled task (🔑) |
+| **Display Monitor** | Choose `Primary Monitor` / `Mouse Monitor` |
+| **Quit** | Exit |
 
-配置保存在`config.ini`文件中，有两种方式可以修改配置：
+---
 
-1. 直接修改程序目录下的`config.ini`文件，并重启程序
-2. 🌟\[推荐\] 使用托盘菜单（右键托盘图标）中的`Settings`选项，此时会自动用`notepad`打开配置文件；
-   修改后，保存并**关闭文件**，程序会自动重载配置
+## ⚙ Configuration
 
-### 配置项
+### Files
 
-#### 字体
+| File | Path | Purpose | Auto-overwritten? |
+|:---|:---|:---|:---:|
+| `config.ini` | `<exe dir>/config.ini` | Active configuration; default content with **bilingual (CN/EN)** comments is generated on first launch | ❌ Never overwritten by program |
+| `config.template.ini` | `<exe dir>/config.template.ini` | Up-to-date reference doc with full bilingual comments | ✅ Overwritten on every launch |
 
-```ini
-[label]
-font_family = "Microsoft YaHei UI"
-font_size = 10
+> Hot reload: edit via tray `Settings`, save and close notepad. Or edit and restart the program.
+
+**Conventions**:
+
+- Color: `#AARRGGBB` (alpha-prefixed; `A=ff` opaque, `A=00` transparent)
+- Margin: `L,T,R,B` (left, top, right, bottom in pixels)
+- Font fallback chain: `Microsoft YaHei UI` → `Microsoft YaHei` → `Consolas`
+
+### `[app_switcher]` — Alt+Tab Cross-App Switcher
+
+| Key | Default | Description |
+|:---|:---:|:---|
+| `icon_size` | `64` | App icon size (px) |
+| `icon_padding` | `8,8,8,8` | Inner padding around the icon (defines the grid cell size) |
+| `background_color` | `#64191919` | Popup background |
+| `selected_bg` | `#c8505050` | Selected item background |
+| `hover_bg` | `#64323232` | Hover item background |
+| `border_radius` | `8` | Corner radius for selected / hover |
+| `label_color` | `#fff0f0f0` | Description text color |
+| `label_font_size` | `10` | Description font size (pt) |
+| `label_font_family` | `Microsoft YaHei UI` | Description font family |
+| `label_top_gap` | `0` | Extra gap between label and icon (can be negative) |
+| `label_bottom_gap` | `0` | Extra gap between label and popup bottom |
+| `badge_bg` | `#ff857261` | Badge background |
+| `badge_border` | `#32c8c8c8` | Badge border |
+| `badge_text` | `#ffd6c0ab` | Badge text color |
+| `badge_font_size` | `12.8` | Badge text size (pt) |
+
+### `[group_switcher]` — Alt+\` Same-App Multi-Window Switcher
+
+| Key | Default | Description |
+|:---|:---:|:---|
+| `icon_size` | `96` | Top app icon size |
+| `icon_padding` | `12,12,12,8` | Inner padding around the top icon |
+| `item_spacing` | `4` | Vertical gap between items |
+| `item_padding` | `12,6,12,6` | Inner padding within an item |
+| `item_min_width` | `320` | Minimum item width |
+| `item_height` | `28` | Fixed item height |
+| `background_color` | `#64191919` | Popup background |
+| `item_bg` | `#00000000` | Default item background (transparent → popup background shows through) |
+| `selected_bg` | `#c8505050` | Selected item background |
+| `text_color` | `#fff0f0f0` | Default text color |
+| `selected_text` | `#ffffffff` | Selected text color |
+| `font_size` | `10` | Title font size (pt) |
+| `font_family` | `Microsoft YaHei UI` | Title font family |
+| `border_radius` | `6` | Corner radius for the selected item |
+| `max_visible_items` | `15` | Enable scrolling when items exceed this threshold |
+
+### Global
+
+| Key | Default | Description |
+|:---|:---:|:---|
+| `DisplayMonitor` | `1` | Monitor for the popup: `0` = primary, `1` = follow mouse |
+
+---
+
+## 🔑 Runtime & Permissions
+
+- **OS**: Windows 10 / 11 only (frosted glass requires DWM)
+- **Privileges**:
+  - **Standard user** is enough for all switching features
+  - **Administrator** required to manage:
+    - System windows (e.g. Task Manager)
+    - Apps running as administrator (e.g. some game accelerators)
+- **Auto-start**: Tray menu → `Start with Windows`
+  - Standard: writes to `HKCU\...\Run` registry
+  - Admin: creates a scheduled task (🔑); auto-start also runs as administrator
+
+---
+
+## 🔧 Building
+
+### Dependencies
+
+- Visual Studio 2022 with MSVC v143 toolchain
+- Qt 6.11+ for MSVC 2022 64-bit (default `C:/Qt/6.11.0/msvc2022_64`; adjust `CMAKE_PREFIX_PATH` in [CMakeLists.txt](CMakeLists.txt))
+- CMake 3.29+
+
+### Release Build
+
+```bash
+cmake -S . -B build
+cmake --build build --config Release
 ```
 
-## 🧐Reference
+Outputs go to `build/Release/`:
 
+- `AltTaber.exe` — main executable
+- Qt runtime DLLs (auto-deployed via `windeployqt`)
+- `README.md`, `doc/`, `img/` — copied as part of the release package
+- `config.ini`, `config.template.ini` — generated on first launch
+
+Or run [`build_release.sh`](build_release.sh).
+
+### Disabling Qt Auto-Deploy
+
+`CMakeLists.txt` exposes `ALTTABER_AUTO_DEPLOY_QT` (default `ON`). After building, runtime DLLs are copied with `copy_if_different` and Qt is deployed via `windeployqt --no-compiler-runtime`. To disable:
+
+```bash
+cmake -S . -B build -DALTTABER_AUTO_DEPLOY_QT=OFF
+```
+
+---
+
+## 🧐 Credits
+
+References & inspiration:
+
+- [MrBeanCpp/AltTaber](https://github.com/MrBeanCpp/AltTaber) — upstream project
 - [window-switcher](https://github.com/sigoden/window-switcher)
 - [cmdtab](https://github.com/stianhoiland/cmdtab)
+
+---
+
+## 📜 License
+
+MIT

--- a/build_release.sh
+++ b/build_release.sh
@@ -1,0 +1,3 @@
+cmake -S . -B build
+cmake --build build --config Release
+

--- a/doc/README.en.md
+++ b/doc/README.en.md
@@ -1,0 +1,255 @@
+# AltTaber
+
+![Language](https://img.shields.io/badge/language-C++20-239120)
+![Framework](https://img.shields.io/badge/framework-Qt%206-41cd52)
+![OS](https://img.shields.io/badge/OS-Windows%2010%2F11-0078D4)
+![License](https://img.shields.io/badge/license-MIT-blue)
+
+> A macOS-style `Alt-Tab` window/application switcher built for **Windows** 💻.
+
+🔗 **GitHub**: <https://github.com/tutumumu777/AltTaber>
+🌐 **Languages**: **English** · [简体中文](README.zh-CN.md)
+
+![ui](../img/ui.png)
+
+---
+
+## 📑 Table of Contents
+
+- [⚡ Features](#-features)
+- [⌨️ Keyboard Shortcuts](#️-keyboard-shortcuts)
+- [🌟 Visual Highlights](#-visual-highlights)
+- [🖱 System Tray](#-system-tray)
+- [⚙ Configuration](#-configuration)
+- [🔑 Runtime & Permissions](#-runtime--permissions)
+- [🔧 Building](#-building)
+- [🧐 Credits](#-credits)
+
+---
+
+## ⚡ Features
+
+### 1. `Alt+Tab` — Switch Across Applications
+
+- Horizontal icon grid; **most recently used (MRU)** apps come first
+- Hold `Shift` to reverse
+- Releasing `Alt` switches to the most recently active window of the selected app
+- A **badge** at the top-right of each icon shows the number of open windows for that app
+
+![switch apps](../img/Alt_tab.gif)
+
+### 2. ``Alt+` `` — Switch Between Windows of the Same App
+
+- **New vertical layout**: a large app icon at the top, list of window titles below
+- Hold `Shift` to reverse
+- Most recently active window first
+- A thin scrollbar appears automatically when items exceed the threshold (default `15`, configurable)
+
+![switch windows](../img/Alt_%60.gif)
+
+> **Mode mutual switching** (v0.5+): pressing ``Alt+` `` while the Alt+Tab popup is shown switches you into the same-app window list (based on the currently selected app); and vice versa. No need to release `Alt` in between.
+
+### 3. Mouse Wheel on the Switcher — Switch / Minimize Windows
+
+With the `Alt+Tab` popup visible, hover over an app icon and scroll:
+
+- **Wheel up** ⬆️: bring the next window of that app to front (without taking focus)
+- **Wheel down** ⬇️: **minimize** the current window
+
+![wheel](../img/Alt_Wheel.gif)
+
+### 4. Wheel on Taskbar Icons 🚧 `Beta`
+
+> [!CAUTION]
+> Experimental. May not work for some applications.
+
+Just scroll the wheel on a taskbar icon to switch windows of that app:
+
+- **Wheel up** ⬆️: switch to the previous window
+- **Wheel down** ⬇️: minimize the current window
+
+![taskbar wheel](../img/Taskbar_Wheel.gif)
+
+### 5. Keyboard Operations (When the Switcher Is Visible)
+
+- Arrow keys:
+  - ⬅️ ➡️: select previous / next app
+  - ⬆️ ⬇️: mapped to wheel up / down (switch / minimize windows)
+- Vim-style:
+  - `h` / `l`: select previous / next app
+  - `j` / `k`: switch / minimize windows
+- `Tab` / `Shift+Tab`: equivalent to ⬅️ / ➡️
+
+---
+
+## ⌨️ Keyboard Shortcuts
+
+| Shortcut | Action |
+|:---:|:---|
+| `Alt+Tab` | Show the cross-app switcher; keep pressing `Tab` to cycle |
+| `Alt+Shift+Tab` | Reverse cycle |
+| ``Alt+` `` | Show the same-app window switcher |
+| ``Alt+Shift+` `` | Reverse cycle |
+| `←` `→` / `h` `l` | Select prev / next app within the switcher |
+| `↑` `↓` / `j` `k` | Switch / minimize windows (same as wheel) |
+| Release `Alt` | Commit selection and switch to the target window |
+| Wheel on a switcher icon | Switch / minimize windows of that app |
+| Wheel on a taskbar icon | Same (Beta) |
+
+---
+
+## 🌟 Visual Highlights
+
+- **Acrylic / frosted-glass** background blur
+  ![bg blur](../img/bg-blur.png)
+- Adapts to **Win11 rounded corners**
+- **Window-count badge** at the top-right of each app icon
+  ![app badge](../img/app%20badge.png)
+- Custom **QQ chat-partner avatar** overlaid on the QQ icon
+  ![qq avatar](../img/app%20qq%20avatar.png)
+- Full **HiDPI / multi-monitor** support
+- Configurable display monitor: **mouse-tracked** / **primary** (toggle via tray menu)
+- Every visual property (icon size, font, color, padding, radius, scroll threshold...) is configurable through INI with hot-reload
+
+---
+
+## 🖱 System Tray
+
+Right-click the tray icon to access:
+
+| Menu | Description |
+|:---|:---|
+| **Check for Updates** | Check the latest GitHub release |
+| **Settings** | Open `config.ini` in `notepad.exe`; **auto-reload after closing notepad** |
+| **Start with Windows** | Toggle auto-start; user-mode → registry, admin-mode → scheduled task (🔑) |
+| **Display Monitor** | Choose `Primary Monitor` / `Mouse Monitor` |
+| **Quit** | Exit |
+
+---
+
+## ⚙ Configuration
+
+### Files
+
+| File | Path | Purpose | Auto-overwritten? |
+|:---|:---|:---|:---:|
+| `config.ini` | `<exe dir>/config.ini` | Active configuration; default content with **bilingual (CN/EN)** comments is generated on first launch | ❌ Never overwritten by program |
+| `config.template.ini` | `<exe dir>/config.template.ini` | Up-to-date reference doc with full bilingual comments | ✅ Overwritten on every launch |
+
+> Hot reload: edit via tray `Settings`, save and close notepad. Or edit and restart the program.
+
+**Conventions**:
+
+- Color: `#AARRGGBB` (alpha-prefixed; `A=ff` opaque, `A=00` transparent)
+- Margin: `L,T,R,B` (left, top, right, bottom in pixels)
+- Font fallback chain: `Microsoft YaHei UI` → `Microsoft YaHei` → `Consolas`
+
+### `[app_switcher]` — Alt+Tab Cross-App Switcher
+
+| Key | Default | Description |
+|:---|:---:|:---|
+| `icon_size` | `64` | App icon size (px) |
+| `icon_padding` | `8,8,8,8` | Inner padding around the icon (defines the grid cell size) |
+| `background_color` | `#64191919` | Popup background |
+| `selected_bg` | `#c8505050` | Selected item background |
+| `hover_bg` | `#64323232` | Hover item background |
+| `border_radius` | `8` | Corner radius for selected / hover |
+| `label_color` | `#fff0f0f0` | Description text color |
+| `label_font_size` | `10` | Description font size (pt) |
+| `label_font_family` | `Microsoft YaHei UI` | Description font family |
+| `label_top_gap` | `0` | Extra gap between label and icon (can be negative) |
+| `label_bottom_gap` | `0` | Extra gap between label and popup bottom |
+| `badge_bg` | `#ff857261` | Badge background |
+| `badge_border` | `#32c8c8c8` | Badge border |
+| `badge_text` | `#ffd6c0ab` | Badge text color |
+| `badge_font_size` | `12.8` | Badge text size (pt) |
+
+### `[group_switcher]` — Alt+\` Same-App Multi-Window Switcher
+
+| Key | Default | Description |
+|:---|:---:|:---|
+| `icon_size` | `96` | Top app icon size |
+| `icon_padding` | `12,12,12,8` | Inner padding around the top icon |
+| `item_spacing` | `4` | Vertical gap between items |
+| `item_padding` | `12,6,12,6` | Inner padding within an item |
+| `item_min_width` | `320` | Minimum item width |
+| `item_height` | `28` | Fixed item height |
+| `background_color` | `#64191919` | Popup background |
+| `item_bg` | `#00000000` | Default item background (transparent → popup background shows through) |
+| `selected_bg` | `#c8505050` | Selected item background |
+| `text_color` | `#fff0f0f0` | Default text color |
+| `selected_text` | `#ffffffff` | Selected text color |
+| `font_size` | `10` | Title font size (pt) |
+| `font_family` | `Microsoft YaHei UI` | Title font family |
+| `border_radius` | `6` | Corner radius for the selected item |
+| `max_visible_items` | `15` | Enable scrolling when items exceed this threshold |
+
+### Global
+
+| Key | Default | Description |
+|:---|:---:|:---|
+| `DisplayMonitor` | `1` | Monitor for the popup: `0` = primary, `1` = follow mouse |
+
+---
+
+## 🔑 Runtime & Permissions
+
+- **OS**: Windows 10 / 11 only (frosted glass requires DWM)
+- **Privileges**:
+  - **Standard user** is enough for all switching features
+  - **Administrator** required to manage:
+    - System windows (e.g. Task Manager)
+    - Apps running as administrator (e.g. some game accelerators)
+- **Auto-start**: Tray menu → `Start with Windows`
+  - Standard: writes to `HKCU\...\Run` registry
+  - Admin: creates a scheduled task (🔑); auto-start also runs as administrator
+
+---
+
+## 🔧 Building
+
+### Dependencies
+
+- Visual Studio 2022 with MSVC v143 toolchain
+- Qt 6.11+ for MSVC 2022 64-bit (default `C:/Qt/6.11.0/msvc2022_64`; adjust `CMAKE_PREFIX_PATH` in [CMakeLists.txt](../CMakeLists.txt))
+- CMake 3.29+
+
+### Release Build
+
+```bash
+cmake -S . -B build
+cmake --build build --config Release
+```
+
+Outputs go to `build/Release/`:
+
+- `AltTaber.exe` — main executable
+- Qt runtime DLLs (auto-deployed via `windeployqt`)
+- `README.md`, `doc/`, `img/` — copied as part of the release package
+- `config.ini`, `config.template.ini` — generated on first launch
+
+Or run [`build_release.sh`](../build_release.sh).
+
+### Disabling Qt Auto-Deploy
+
+`CMakeLists.txt` exposes `ALTTABER_AUTO_DEPLOY_QT` (default `ON`). After building, runtime DLLs are copied with `copy_if_different` and Qt is deployed via `windeployqt --no-compiler-runtime`. To disable:
+
+```bash
+cmake -S . -B build -DALTTABER_AUTO_DEPLOY_QT=OFF
+```
+
+---
+
+## 🧐 Credits
+
+References & inspiration:
+
+- [MrBeanCpp/AltTaber](https://github.com/MrBeanCpp/AltTaber) — upstream project
+- [window-switcher](https://github.com/sigoden/window-switcher)
+- [cmdtab](https://github.com/stianhoiland/cmdtab)
+
+---
+
+## 📜 License
+
+MIT

--- a/doc/README.zh-CN.md
+++ b/doc/README.zh-CN.md
@@ -1,0 +1,255 @@
+# AltTaber 中文文档
+
+![Language](https://img.shields.io/badge/language-C++20-239120)
+![Framework](https://img.shields.io/badge/framework-Qt%206-41cd52)
+![OS](https://img.shields.io/badge/OS-Windows%2010%2F11-0078D4)
+![License](https://img.shields.io/badge/license-MIT-blue)
+
+> 一款 macOS 风格的 `Alt-Tab` 窗口/应用切换器，专为 **Windows** 💻 打造。
+
+🔗 **GitHub**: <https://github.com/tutumumu777/AltTaber>
+🌐 **Languages**: [English](README.en.md) · **简体中文**
+
+![ui](../img/ui.png)
+
+---
+
+## 📑 目录
+
+- [⚡ 功能总览](#-功能总览)
+- [⌨️ 快捷键速查](#️-快捷键速查)
+- [🌟 视觉特色](#-视觉特色)
+- [🖱 系统托盘](#-系统托盘)
+- [⚙ 配置文件](#-配置文件)
+- [🔑 运行环境与权限](#-运行环境与权限)
+- [🔧 构建](#-构建)
+- [🧐 致谢](#-致谢)
+
+---
+
+## ⚡ 功能总览
+
+### 1. `Alt+Tab` —— 在应用程序之间切换
+
+- 横向图标网格，**最近使用 (MRU)** 的应用排在最左
+- 按住 `Shift` 反向切换
+- 松开 `Alt` 自动切换到选中应用的「最近活跃」窗口
+- 应用图标右上角 **Badge** 显示该应用打开的窗口数量
+
+![switch apps](../img/Alt_tab.gif)
+
+### 2. ``Alt+` `` —— 在同一应用的不同窗口之间切换
+
+- **新版竖向布局**：浮窗顶部显示应用大图标，下方为该应用所有窗口的标题列表
+- 按住 `Shift` 反向切换
+- 「最近活跃」窗口优先
+- 条目较多时自动启用细滚动条（默认 > 15 时滚动）
+
+![switch windows](../img/Alt_%60.gif)
+
+> **模式互斥**（v0.5+）：在 `Alt+Tab` 浮窗显示时按 ``Alt+` `` 会切换到同应用窗口列表（基于当前选中应用）；反之亦然。无需先松 `Alt`。
+
+### 3. 切换器内的鼠标滚轮 —— 切换/最小化指定应用的窗口
+
+`Alt+Tab` 呼出切换器后，鼠标悬停某个应用图标时：
+
+- **向上滚** ⬆️：将该应用的下一个窗口浮到最前（不切焦点）
+- **向下滚** ⬇️：**最小化**当前对应窗口
+
+![wheel](../img/Alt_Wheel.gif)
+
+### 4. 任务栏滚轮切换窗口 🚧 `Beta`
+
+> [!CAUTION]
+> 实验性功能，仍在测试中。某些应用可能不生效。
+
+直接在任务栏的应用图标上滚轮即可切换该应用的窗口：
+
+- **向上滚** ⬆️：切换到上一个窗口
+- **向下滚** ⬇️：最小化当前窗口
+
+![taskbar wheel](../img/Taskbar_Wheel.gif)
+
+### 5. 键盘操作（在切换器显示时）
+
+- 方向键：
+  - ⬅️ ➡️：左/右切换当前选中应用
+  - ⬆️ ⬇️：映射为滚轮上下，切换/最小化窗口
+- Vim 风格：
+  - `h` / `l`：左右切换当前选中应用
+  - `j` / `k`：上下切换/最小化窗口
+- `Tab` / `Shift+Tab`：等价于左右方向键
+
+---
+
+## ⌨️ 快捷键速查
+
+| 快捷键 | 功能 |
+|:---:|:---|
+| `Alt+Tab` | 显示跨应用切换器；持续按 `Tab` 循环切换 |
+| `Alt+Shift+Tab` | 反向循环 |
+| ``Alt+` `` | 显示同应用多窗口切换器；持续按 `` ` `` 循环切换 |
+| ``Alt+Shift+` `` | 反向循环 |
+| `←` `→` / `h` `l` | 在切换器内左右选择应用 |
+| `↑` `↓` / `j` `k` | 在切换器内切换/最小化窗口（等同滚轮） |
+| 松开 `Alt` | 提交选择并切换到目标窗口 |
+| 鼠标在切换器图标上滚动 | 切换/最小化该应用的窗口 |
+| 鼠标在任务栏图标上滚动 | 同上（Beta） |
+
+---
+
+## 🌟 视觉特色
+
+- **亚克力 / 毛玻璃** 背景模糊
+  ![bg blur](../img/bg-blur.png)
+- 适配 **Win11 圆角**
+- 应用图标右上角显示窗口数 **Badge**
+  ![app badge](../img/app%20badge.png)
+- **QQ 🐧** 图标右下角显示当前聊天好友头像
+  ![qq avatar](../img/app%20qq%20avatar.png)
+- 完整支持 **高 DPI 缩放、多显示器**
+- 浮窗显示位置：**跟随鼠标所在屏幕** / **主屏幕** 可切换（托盘菜单）
+- 全部样式（图标尺寸、字体、颜色、间距、圆角、滚动阈值等）均可通过 INI 配置 + 热重载
+
+---
+
+## 🖱 系统托盘
+
+右键托盘图标可看到以下菜单：
+
+| 菜单项 | 说明 |
+|:---|:---|
+| **Check for Updates** | 检查 GitHub 最新版本并提示更新 |
+| **Settings** | 用 `notepad.exe` 打开 `config.ini`，**关闭 notepad 后自动热重载** |
+| **Start with Windows** | 开机自启动开关；普通权限走注册表，管理员权限走计划任务（🔑） |
+| **Display Monitor** | 切换浮窗显示屏：`Primary Monitor` / `Mouse Monitor` |
+| **Quit** | 退出 |
+
+---
+
+## ⚙ 配置文件
+
+### 配置文件位置
+
+| 文件 | 路径 | 用途 | 是否会被覆盖 |
+|:---|:---|:---|:---:|
+| `config.ini` | `<exe目录>/config.ini` | 实际生效的配置；首次启动自动生成默认带**中英双语注释**版本 | ❌ 不会被程序覆盖 |
+| `config.template.ini` | `<exe目录>/config.template.ini` | 与代码同步的最新参考文档（含完整中英双语注释） | ✅ **每次启动覆盖**为最新 |
+
+> 修改 `config.ini` 后，从托盘菜单 `Settings` 打开关闭即可热重载；或直接编辑后重启程序。
+
+**格式约定**：
+
+- 颜色：`#AARRGGBB`（含 alpha 通道，`A=ff` 不透明，`A=00` 全透明）
+- 边距：`L,T,R,B`（左、上、右、下，单位像素）
+- 字体名错误时回退链：`Microsoft YaHei UI` → `Microsoft YaHei` → `Consolas`
+
+### Alt+Tab 跨应用切换样式 `[app_switcher]`
+
+| Key | 默认值 | 说明 |
+|:---|:---:|:---|
+| `icon_size` | `64` | 应用图标边长（像素） |
+| `icon_padding` | `8,8,8,8` | 图标四周内边距 L,T,R,B（决定网格单元大小） |
+| `background_color` | `#64191919` | 浮窗整体背景色 |
+| `selected_bg` | `#c8505050` | 选中条目背景色 |
+| `hover_bg` | `#64323232` | 鼠标悬停背景色 |
+| `border_radius` | `8` | 选中/悬停背景圆角半径 |
+| `label_color` | `#fff0f0f0` | 底部应用描述文字色 |
+| `label_font_size` | `10` | 底部描述字号（pt） |
+| `label_font_family` | `Microsoft YaHei UI` | 底部描述字体 |
+| `label_top_gap` | `0` | 描述与图标的额外上间距（可负） |
+| `label_bottom_gap` | `0` | 描述与浮窗下边的额外下间距 |
+| `badge_bg` | `#ff857261` | 多窗口数 Badge 背景色 |
+| `badge_border` | `#32c8c8c8` | Badge 边框色 |
+| `badge_text` | `#ffd6c0ab` | Badge 文字色 |
+| `badge_font_size` | `12.8` | Badge 文字字号（pt） |
+
+### Alt+\` 同应用多窗口切换样式 `[group_switcher]`
+
+| Key | 默认值 | 说明 |
+|:---|:---:|:---|
+| `icon_size` | `96` | 顶部应用大图标边长 |
+| `icon_padding` | `12,12,12,8` | 顶部图标四周内边距 |
+| `item_spacing` | `4` | 标题条目之间的纵向间距 |
+| `item_padding` | `12,6,12,6` | 条目内文字与四边的内边距 |
+| `item_min_width` | `320` | 条目最小宽度 |
+| `item_height` | `28` | 条目固定高度 |
+| `background_color` | `#64191919` | 浮窗整体背景色 |
+| `item_bg` | `#00000000` | 默认条目背景色（透明 = 让浮窗背景透出） |
+| `selected_bg` | `#c8505050` | 选中条目背景色 |
+| `text_color` | `#fff0f0f0` | 默认文字色 |
+| `selected_text` | `#ffffffff` | 选中条目文字色 |
+| `font_size` | `10` | 标题字号（pt） |
+| `font_family` | `Microsoft YaHei UI` | 标题字体 |
+| `border_radius` | `6` | 选中条目背景圆角半径 |
+| `max_visible_items` | `15` | 条目数超过此阈值时启用滚动 |
+
+### 其他全局项
+
+| Key | 默认值 | 说明 |
+|:---|:---:|:---|
+| `DisplayMonitor` | `1` | 浮窗显示在哪个屏幕：`0`=主显示器，`1`=跟随鼠标 |
+
+---
+
+## 🔑 运行环境与权限
+
+- **OS**：仅支持 Windows 10 / 11（毛玻璃需要 DWM）
+- **权限**：
+  - **普通用户** 即可使用所有切换功能
+  - 需要 **管理员权限** 才能管理：
+    - 系统窗口（如任务管理器）
+    - 管理员权限运行的应用（如某些游戏加速器）
+- **开机自启**：托盘菜单 `Start with Windows`
+  - 普通权限：写入用户注册表的 `Run` 项
+  - 管理员权限：创建计划任务（🔑），自启时也以管理员权限运行
+
+---
+
+## 🔧 构建
+
+### 依赖
+
+- Visual Studio 2022（含 MSVC v143 工具链）
+- Qt 6.11+ for MSVC 2022 64-bit（默认路径 `C:/Qt/6.11.0/msvc2022_64`，可在 [CMakeLists.txt](../CMakeLists.txt) 中调整 `CMAKE_PREFIX_PATH`）
+- CMake 3.29+
+
+### Release 构建
+
+```bash
+cmake -S . -B build
+cmake --build build --config Release
+```
+
+构建产物会输出到 `build/Release/`：
+
+- `AltTaber.exe` —— 主程序
+- 自动通过 `windeployqt` 部署所需 Qt DLL
+- `README.md`、`doc/`、`img/` 会随构建一同放到该目录
+- `config.ini`、`config.template.ini` 在程序首次启动时生成
+
+或者直接执行项目根目录下的 [`build_release.sh`](../build_release.sh)。
+
+### 控制 Qt 自动部署
+
+`CMakeLists.txt` 提供选项 `ALTTABER_AUTO_DEPLOY_QT`（默认 `ON`），构建后会自动 `copy_if_different` 运行时 DLL 并调用 `windeployqt --no-compiler-runtime` 部署 Qt。如果你已把 Qt DLL 放进 PATH 或想自行部署，可关掉：
+
+```bash
+cmake -S . -B build -DALTTABER_AUTO_DEPLOY_QT=OFF
+```
+
+---
+
+## 🧐 致谢
+
+参考与启发：
+
+- [MrBeanCpp/AltTaber](https://github.com/MrBeanCpp/AltTaber) —— 上游项目
+- [window-switcher](https://github.com/sigoden/window-switcher)
+- [cmdtab](https://github.com/stianhoiland/cmdtab)
+
+---
+
+## 📜 License
+
+MIT

--- a/header/GroupSwitcherWidget.h
+++ b/header/GroupSwitcherWidget.h
@@ -1,0 +1,65 @@
+﻿#ifndef WIN_SWITCHER_GROUPSWITCHERWIDGET_H
+#define WIN_SWITCHER_GROUPSWITCHERWIDGET_H
+
+#include <QWidget>
+#include <QList>
+#include <QIcon>
+#include <Windows.h>
+#include "utils/ConfigManager.h"
+
+class QLabel;
+class QListWidget;
+class GroupItemDelegate;
+
+/// Alt+` 同应用多窗口切换浮窗：
+///   ┌────────────────────────────┐
+///   │         [App Icon]         │   <- 顶部居中单个大图标
+///   │                            │
+///   │  window title 1            │   <- 竖向窗口标题列表（仅文字，无编号）
+///   │  window title 2  (selected)│
+///   │  window title 3            │
+///   └────────────────────────────┘
+///
+/// 仅做被动展示：键盘事件由 Widget（KeyboardHooker 的固定 receiver）统一处理。
+/// 该窗口不抢占焦点，避免破坏 Widget 与全局键盘钩子的协作。
+class GroupSwitcherWidget : public QWidget {
+    Q_OBJECT
+
+public:
+    explicit GroupSwitcherWidget(QWidget* parent = nullptr);
+
+    /// 首次显示或窗口列表变化时调用：重建条目并显示
+    void showFor(const QList<HWND>& windows, int currentIndex,
+                 const QIcon& appIcon, const QString& exePath);
+
+    /// 已显示状态下旋转选中项（不重建列表）
+    void setCurrentIndex(int idx);
+
+    int currentIndex() const;
+    HWND currentHwnd() const;
+    int count() const { return m_windows.size(); }
+
+    HWND hWnd() { return reinterpret_cast<HWND>(winId()); }
+
+protected:
+    void paintEvent(QPaintEvent* event) override;
+    void showEvent(QShowEvent* event) override;
+
+private:
+    void reloadStyle();        // 读取最新 GroupSwitcherStyle 并应用到子控件 + 触发重排
+    void rebuildItems();       // 用 m_windows 重建 m_listWidget 的条目
+    void recomputeGeometry();  // 根据条目内容 + 样式计算并应用窗口/子控件尺寸位置
+    void positionOnScreen();   // 居中到目标屏幕（沿用 cfg.getDisplayMonitor() 策略）
+
+    QLabel* m_iconLabel = nullptr;
+    QListWidget* m_listWidget = nullptr;
+    GroupItemDelegate* m_delegate = nullptr;
+
+    QList<HWND> m_windows;
+    QString m_exePath;
+    QIcon m_appIcon;
+    GroupSwitcherStyle m_style;
+};
+
+
+#endif //WIN_SWITCHER_GROUPSWITCHERWIDGET_H

--- a/header/utils/ConfigManager.h
+++ b/header/utils/ConfigManager.h
@@ -3,6 +3,8 @@
 
 #include <QSettings>
 #include <QApplication>
+#include <QColor>
+#include <QMargins>
 #include "ConfigManagerBase.h"
 
 // 注意：对于大量使用的类，header-only 模式会导致编译时间过长
@@ -14,15 +16,63 @@ enum DisplayMonitor {
     EnumCount // Just for count
 };
 
+/// Alt+Tab 跨应用切换器（横向图标网格）样式
+struct AppSwitcherStyle {
+    int iconSize = 64;                                  // app_switcher/icon_size
+    QMargins iconPadding{8, 8, 8, 8};                   // app_switcher/icon_padding "L,T,R,B"
+    QColor backgroundColor{25, 25, 25, 100};            // app_switcher/background_color
+    QColor selectedColor{80, 80, 80, 200};              // app_switcher/selected_bg
+    QColor hoverColor{50, 50, 50, 100};                 // app_switcher/hover_bg
+    int borderRadius = 8;                               // app_switcher/border_radius
+    QColor labelColor{240, 240, 240};                   // app_switcher/label_color
+    int labelFontSize = 10;                             // app_switcher/label_font_size (fallback: label/font_size)
+    int labelTopGap = 0;                                // app_switcher/label_top_gap
+    int labelBottomGap = 0;                             // app_switcher/label_bottom_gap
+    QString labelFontFamily{"Microsoft YaHei UI"};      // app_switcher/label_font_family (fallback: label/font_family)
+    // Badge
+    QColor badgeBg{133, 114, 97};                       // app_switcher/badge_bg
+    QColor badgeBorder{200, 200, 200, 50};              // app_switcher/badge_border
+    QColor badgeText{214, 192, 171};                    // app_switcher/badge_text
+    qreal badgeFontSize = 12.8;                         // app_switcher/badge_font_size
+};
+
+/// Alt+` 同应用多窗口切换器（顶部大图标 + 竖向标题列表）样式
+struct GroupSwitcherStyle {
+    int iconSize = 96;                                  // group_switcher/icon_size
+    QMargins iconPadding{12, 12, 12, 8};                // group_switcher/icon_padding "L,T,R,B"
+    int itemSpacing = 4;                                // group_switcher/item_spacing
+    QMargins itemPadding{12, 6, 12, 6};                 // group_switcher/item_padding "L,T,R,B"
+    int itemMinWidth = 320;                             // group_switcher/item_min_width
+    int itemHeight = 28;                                // group_switcher/item_height
+    QColor backgroundColor{25, 25, 25, 100};            // group_switcher/background_color
+    QColor itemBackground{0, 0, 0, 0};                  // group_switcher/item_bg (transparent)
+    QColor selectedItemBg{80, 80, 80, 200};             // group_switcher/selected_bg
+    QColor textColor{240, 240, 240};                    // group_switcher/text_color
+    QColor selectedTextColor{255, 255, 255};            // group_switcher/selected_text
+    int fontSize = 10;                                  // group_switcher/font_size
+    QString fontFamily{"Microsoft YaHei UI"};           // group_switcher/font_family
+    int borderRadius = 6;                               // group_switcher/border_radius
+    int maxVisibleItems = 15;                           // group_switcher/max_visible_items：超过该数量则启用滚动
+};
+
 class ConfigManager : public ConfigManagerBase {
     inline static const QString FileName = "config.ini";
+    inline static const QString TemplateFileName = "config.template.ini";
 
 public:
     ConfigManager(const ConfigManager&) = delete;
     ConfigManager& operator=(const ConfigManager&) = delete;
 
     static ConfigManager& instance() {
-        static const auto filePath = QApplication::applicationDirPath() + "/" + FileName;
+        static const auto dir = QApplication::applicationDirPath();
+        static const auto filePath = dir + "/" + FileName;
+        // 首次访问时准备：
+        //   1) config.ini 不存在或为空时，写入默认内容（仅初次，不覆盖用户配置）
+        //   2) config.template.ini 每次启动覆盖写出以保持与代码同步
+        static const bool _prep = (
+            ensureDefaultConfig(filePath),
+            writeTemplateFile(dir + "/" + TemplateFileName), true);
+        Q_UNUSED(_prep);
         static ConfigManager instance{filePath}; // multiple threads safe
         return instance;
     }
@@ -41,8 +91,302 @@ public:
         set("DisplayMonitor", monitor);
     }
 
+    /// 加载 Alt+Tab 切换器样式（缺失项使用默认值）
+    AppSwitcherStyle loadAppStyle() {
+        AppSwitcherStyle s;
+        s.iconSize         = get("app_switcher/icon_size", s.iconSize).toInt();
+        s.iconPadding      = parseMargins(get("app_switcher/icon_padding"), s.iconPadding);
+        s.backgroundColor  = parseColor(get("app_switcher/background_color"), s.backgroundColor);
+        s.selectedColor    = parseColor(get("app_switcher/selected_bg"), s.selectedColor);
+        s.hoverColor       = parseColor(get("app_switcher/hover_bg"), s.hoverColor);
+        s.borderRadius     = get("app_switcher/border_radius", s.borderRadius).toInt();
+        s.labelColor       = parseColor(get("app_switcher/label_color"), s.labelColor);
+        // labelFontSize / labelFontFamily 兼容旧 key label/font_size, label/font_family
+        s.labelFontSize    = get("app_switcher/label_font_size", get("label/font_size", s.labelFontSize)).toInt();
+        s.labelFontFamily  = get("app_switcher/label_font_family", get("label/font_family", s.labelFontFamily)).toString();
+        s.labelTopGap      = get("app_switcher/label_top_gap", s.labelTopGap).toInt();
+        s.labelBottomGap   = get("app_switcher/label_bottom_gap", s.labelBottomGap).toInt();
+        s.badgeBg          = parseColor(get("app_switcher/badge_bg"), s.badgeBg);
+        s.badgeBorder      = parseColor(get("app_switcher/badge_border"), s.badgeBorder);
+        s.badgeText        = parseColor(get("app_switcher/badge_text"), s.badgeText);
+        s.badgeFontSize    = get("app_switcher/badge_font_size", s.badgeFontSize).toReal();
+        return s;
+    }
+
+    /// 加载 Alt+` 组内切换器样式（缺失项使用默认值）
+    GroupSwitcherStyle loadGroupStyle() {
+        GroupSwitcherStyle s;
+        s.iconSize          = get("group_switcher/icon_size", s.iconSize).toInt();
+        s.iconPadding       = parseMargins(get("group_switcher/icon_padding"), s.iconPadding);
+        s.itemSpacing       = get("group_switcher/item_spacing", s.itemSpacing).toInt();
+        s.itemPadding       = parseMargins(get("group_switcher/item_padding"), s.itemPadding);
+        s.itemMinWidth      = get("group_switcher/item_min_width", s.itemMinWidth).toInt();
+        s.itemHeight        = get("group_switcher/item_height", s.itemHeight).toInt();
+        s.backgroundColor   = parseColor(get("group_switcher/background_color"), s.backgroundColor);
+        s.itemBackground    = parseColor(get("group_switcher/item_bg"), s.itemBackground);
+        s.selectedItemBg    = parseColor(get("group_switcher/selected_bg"), s.selectedItemBg);
+        s.textColor         = parseColor(get("group_switcher/text_color"), s.textColor);
+        s.selectedTextColor = parseColor(get("group_switcher/selected_text"), s.selectedTextColor);
+        s.fontSize          = get("group_switcher/font_size", s.fontSize).toInt();
+        s.fontFamily        = get("group_switcher/font_family", s.fontFamily).toString();
+        s.borderRadius      = get("group_switcher/border_radius", s.borderRadius).toInt();
+        s.maxVisibleItems   = get("group_switcher/max_visible_items", s.maxVisibleItems).toInt();
+        if (s.maxVisibleItems < 1) s.maxVisibleItems = 1;
+        return s;
+    }
+
 private:
     explicit ConfigManager(const QString& filename) : ConfigManagerBase(filename) {}
+
+    /// 将默认配置模板写入指定路径（覆盖），供用户参考复粘。
+    /// 模板不会被 QSettings 改动，可以安全携带中文注释。
+    static void writeTemplateFile(const QString& path) {
+        QFile f(path);
+        if (!f.open(QIODevice::WriteOnly | QIODevice::Truncate)) {
+            qWarning() << "#Failed to write config template:" << path;
+            return;
+        }
+        f.write(templateContent().toUtf8());
+    }
+
+    /// 首次启动时：若 config.ini 不存在或为空，写入带注释的默认配置。
+    /// 已有用户配置时不动，避免覆盖丢失。
+    static void ensureDefaultConfig(const QString& path) {
+        QFile f(path);
+        if (f.exists() && f.size() > 0) return;
+        if (!f.open(QIODevice::WriteOnly | QIODevice::Truncate)) {
+            qWarning() << "#Failed to write default config:" << path;
+            return;
+        }
+        f.write(defaultConfigContent().toUtf8());
+    }
+
+    /// 模板文件内容：头部说明 + 共用配置主体（中英双语）
+    static QString templateContent() {
+        return QStringLiteral(
+R"(; ============================================================
+;                   AltTaber 配置模板 (config.template.ini)
+; ------------------------------------------------------------
+;  [使用说明]
+;    本文件仅作为参考，不会被程序读取。每次启动会被覆盖为最新版本。
+;    需要调整设置时，请复制需要的项到同目录的 config.ini，
+;    然后在系统托盘 [Settings] 菜单中打开编辑（关闭 notepad 后自动热重载）。
+;
+;  [Usage]
+;    This file is for reference only and is NEVER read by the program.
+;    It will be overwritten on every launch to stay in sync with the latest defaults.
+;    To change settings, copy the keys you need into config.ini in the same directory,
+;    then open it via the tray menu [Settings] (auto-reloaded on close).
+;
+;  [格式约定 / Conventions]
+;    颜色 / Color  : #AARRGGBB  (alpha-prefixed; A=ff opaque, A=00 transparent)
+;    边距 / Margin : L,T,R,B    (left, top, right, bottom in pixels)
+;    字体名错误时会回退到 / Font fallback chain:
+;        Microsoft YaHei UI → Microsoft YaHei → Consolas
+; ============================================================
+)")
+               + commonBody();
+    }
+
+    /// 首次生成的 config.ini 内容：头部说明 + 共用配置主体（中英双语）
+    static QString defaultConfigContent() {
+        return QStringLiteral(
+R"(; ============================================================
+;                AltTaber 配置文件 (config.ini)
+; ------------------------------------------------------------
+;  [中文]
+;    本文件由程序读取并应用。你可以随意修改以下项：
+;      1）从托盘菜单 [Settings] 打开编辑，关闭 notepad 后自动热重载。
+;      2）或直接编辑本文件，修改后重启程序生效。
+;    本文件不会被程序自动覆盖。如需查看最新默认值与详细说明，请参考同目录的
+;    config.template.ini（每次启动自动更新）。
+;
+;  [English]
+;    This file is read and applied by the program. You may freely edit any entry below:
+;      1) Open it via the tray menu [Settings]; auto-reload after closing notepad.
+;      2) Or edit this file directly and restart the program.
+;    This file is NEVER auto-overwritten by the program. For up-to-date defaults and
+;    full documentation, see config.template.ini in the same directory (refreshed on
+;    every launch).
+;
+;  [格式约定 / Conventions]
+;    颜色 / Color  : #AARRGGBB  (alpha-prefixed; A=ff opaque, A=00 transparent)
+;    边距 / Margin : L,T,R,B    (left, top, right, bottom in pixels)
+;    字体名错误时会回退到 / Font fallback chain:
+;        Microsoft YaHei UI → Microsoft YaHei → Consolas
+; ============================================================
+)")
+               + commonBody();
+    }
+
+    /// 共用的配置主体：DisplayMonitor + [app_switcher] + [group_switcher]。
+    /// 所有项采用中英双行注释。
+    static QString commonBody() {
+        return QStringLiteral(
+R"(
+; 浮窗在哪个屏幕显示：0=主显示器  1=跟随鼠标（默认）
+; Which monitor to display the popup on: 0=primary, 1=follow mouse (default)
+DisplayMonitor=1
+
+
+; ============================================================
+; [app_switcher] Alt+Tab 跨应用切换器（横向图标网格）
+; [app_switcher] Alt+Tab cross-app switcher (horizontal icon grid)
+; ============================================================
+[app_switcher]
+
+; 应用图标边长（像素）。默认 64
+; App icon size in pixels. Default: 64
+icon_size=64
+
+; 图标四周内边距 L,T,R,B。决定图标与单元格边界的间隔，从而决定整个网格单元的大小。默认 8,8,8,8
+; Inner padding around the icon (defines the grid cell size). Default: 8,8,8,8
+icon_padding=8,8,8,8
+
+; 浮窗整体背景色。默认 #64191919（半透明深灰）
+; Popup background color. Default: #64191919 (semi-transparent dark gray)
+background_color=#64191919
+
+; 选中条目背景色。默认 #c8505050
+; Selected item background color. Default: #c8505050
+selected_bg=#c8505050
+
+; 鼠标悬停条目背景色。默认 #64323232
+; Hover item background color. Default: #64323232
+hover_bg=#64323232
+
+; 选中/悬停背景的圆角半径。默认 8
+; Corner radius for selected/hover background. Default: 8
+border_radius=8
+
+; 底部应用描述文字颜色。默认 #fff0f0f0
+; Bottom description text color. Default: #fff0f0f0
+label_color=#fff0f0f0
+
+; 底部描述字号（pt）。默认 10。兼容旧 key label/font_size
+; Bottom description font size (pt). Default: 10. (Legacy key label/font_size still works)
+label_font_size=10
+
+; 底部描述字体。默认 Microsoft YaHei UI。兼容旧 key label/font_family
+; Bottom description font family. Default: Microsoft YaHei UI. (Legacy key label/font_family still works)
+label_font_family=Microsoft YaHei UI
+
+; 描述与图标之间的额外上间距（可为负使描述靠近图标）。默认 0
+; Extra gap between label and icon (negative pulls the label closer). Default: 0
+label_top_gap=0
+
+; 描述与浮窗下边之间的额外下间距。默认 0
+; Extra gap between label and the popup bottom edge. Default: 0
+label_bottom_gap=0
+
+; 多窗口数 Badge（右上角小圆点）背景色。默认 #ff857261
+; Window-count badge background (small dot at top-right). Default: #ff857261
+badge_bg=#ff857261
+
+; Badge 边框色。默认 #32c8c8c8
+; Badge border color. Default: #32c8c8c8
+badge_border=#32c8c8c8
+
+; Badge 文字色。默认 #ffd6c0ab
+; Badge text color. Default: #ffd6c0ab
+badge_text=#ffd6c0ab
+
+; Badge 文字字号（pt，支持小数）。默认 12.8
+; Badge text size (pt, fractional supported). Default: 12.8
+badge_font_size=12.8
+
+
+; ============================================================
+; [group_switcher] Alt+\` 同应用多窗口切换器
+; 布局：顶部一个应用大图标 + 下方竖向窗口标题列表。
+; [group_switcher] Alt+\` same-app multi-window switcher.
+; Layout: a large app icon at the top + vertical list of window titles below.
+; ============================================================
+[group_switcher]
+
+; 顶部应用大图标边长。默认 96
+; Top app icon size. Default: 96
+icon_size=96
+
+; 顶部图标四周内边距 L,T,R,B。默认 12,12,12,8
+; Inner padding around the top icon. Default: 12,12,12,8
+icon_padding=12,12,12,8
+
+; 标题条目之间的纵向间距。默认 4
+; Vertical gap between title items. Default: 4
+item_spacing=4
+
+; 条目内文字与四边的内边距 L,T,R,B。默认 12,6,12,6
+; Inner padding within an item. Default: 12,6,12,6
+item_padding=12,6,12,6
+
+; 条目最小宽度（像素）。默认 320
+; Minimum item width in pixels. Default: 320
+item_min_width=320
+
+; 条目固定高度。默认 28
+; Fixed item height. Default: 28
+item_height=28
+
+; 浮窗整体背景色。默认 #64191919
+; Popup background color. Default: #64191919
+background_color=#64191919
+
+; 默认条目背景色（透明=让浮窗背景透出）。默认 #00000000
+; Default item background color (transparent lets popup background show through). Default: #00000000
+item_bg=#00000000
+
+; 选中条目背景色。默认 #c8505050
+; Selected item background color. Default: #c8505050
+selected_bg=#c8505050
+
+; 默认文字色。默认 #fff0f0f0
+; Default text color. Default: #fff0f0f0
+text_color=#fff0f0f0
+
+; 选中条目文字色。默认 #ffffffff
+; Selected item text color. Default: #ffffffff
+selected_text=#ffffffff
+
+; 标题字号（pt）。默认 10
+; Title font size (pt). Default: 10
+font_size=10
+
+; 标题字体。默认 Microsoft YaHei UI
+; Title font family. Default: Microsoft YaHei UI
+font_family=Microsoft YaHei UI
+
+; 选中条目背景的圆角半径。默认 6
+; Corner radius for the selected item background. Default: 6
+border_radius=6
+
+; 条目数超过该阈值时启用滚动（防止浮窗超出屏幕）。默认 15
+; Enable scrolling when items exceed this threshold (prevents popup from overflowing screen). Default: 15
+max_visible_items=15
+)");
+    }
+
+    /// 解析 "#AARRGGBB" / "#RRGGBB" / 命名色；非法则返回 def
+    static QColor parseColor(const QVariant& v, const QColor& def) {
+        if (!v.isValid()) return def;
+        const auto s = v.toString().trimmed();
+        if (s.isEmpty()) return def;
+        QColor c(s);
+        return c.isValid() ? c : def;
+    }
+
+    /// 解析 "L,T,R,B"；非法则返回 def
+    static QMargins parseMargins(const QVariant& v, const QMargins& def) {
+        if (!v.isValid()) return def;
+        const auto parts = v.toString().split(',', Qt::SkipEmptyParts);
+        if (parts.size() != 4) return def;
+        bool ok[4]{};
+        const int l = parts[0].trimmed().toInt(&ok[0]);
+        const int t = parts[1].trimmed().toInt(&ok[1]);
+        const int r = parts[2].trimmed().toInt(&ok[2]);
+        const int b = parts[3].trimmed().toInt(&ok[3]);
+        return (ok[0] && ok[1] && ok[2] && ok[3]) ? QMargins(l, t, r, b) : def;
+    }
 };
 
 

--- a/header/utils/ConfigManagerBase.h
+++ b/header/utils/ConfigManagerBase.h
@@ -3,6 +3,7 @@
 
 #include <QSettings>
 #include <QProcess>
+#include <QFile>
 
 class ConfigManagerBase : public QObject {
     Q_OBJECT

--- a/header/utils/IconOnlyDelegate.h
+++ b/header/utils/IconOnlyDelegate.h
@@ -11,6 +11,7 @@ class IconOnlyDelegate : public QStyledItemDelegate {
     QColor selectedColor;
     QColor hoverColor;
     int radius;
+    bool m_groupSwitcherMode = false; // Alt+` 组内切换模式
 
 public:
     explicit IconOnlyDelegate(QObject* parent = nullptr,
@@ -21,6 +22,10 @@ public:
           radius(radius) {}
 
     void paint(QPainter* painter, const QStyleOptionViewItem& option, const QModelIndex& index) const override;
+
+    /// 切换到组内切换模式：每格上方显示"窗口 N"，下方显示窗口标题
+    void setGroupSwitcherMode(bool enabled) { m_groupSwitcherMode = enabled; }
+    bool isGroupSwitcherMode() const { return m_groupSwitcherMode; }
 };
 
 

--- a/header/utils/IconOnlyDelegate.h
+++ b/header/utils/IconOnlyDelegate.h
@@ -4,28 +4,20 @@
 #include <QStyledItemDelegate>
 #include <QPainter>
 #include <QIcon>
-#include <QColor>
+#include "ConfigManager.h"
 
-/// Icon Only Mode for QListWidget
+/// Icon Only Mode for QListWidget (Alt+Tab 横向应用切换器)
 class IconOnlyDelegate : public QStyledItemDelegate {
-    QColor selectedColor;
-    QColor hoverColor;
-    int radius;
-    bool m_groupSwitcherMode = false; // Alt+` 组内切换模式
+    AppSwitcherStyle m_style; // 默认值见 AppSwitcherStyle 内部初始化器
 
 public:
-    explicit IconOnlyDelegate(QObject* parent = nullptr,
-                              QColor selectedColor = QColor(80, 80, 80, 200),
-                              QColor hoverColor = QColor(50, 50, 50, 100),
-                              int radius = 8)
-        : QStyledItemDelegate(parent), selectedColor(selectedColor), hoverColor(hoverColor),
-          radius(radius) {}
+    explicit IconOnlyDelegate(QObject* parent = nullptr) : QStyledItemDelegate(parent) {}
 
     void paint(QPainter* painter, const QStyleOptionViewItem& option, const QModelIndex& index) const override;
 
-    /// 切换到组内切换模式：每格上方显示"窗口 N"，下方显示窗口标题
-    void setGroupSwitcherMode(bool enabled) { m_groupSwitcherMode = enabled; }
-    bool isGroupSwitcherMode() const { return m_groupSwitcherMode; }
+    /// 应用样式（首次以及配置热重载时调用）
+    void applyStyle(const AppSwitcherStyle& style) { m_style = style; }
+    const AppSwitcherStyle& style() const { return m_style; }
 };
 
 

--- a/header/widget.h
+++ b/header/widget.h
@@ -5,8 +5,10 @@
 #include <Windows.h>
 #include <QListWidget>
 #include <QDebug>
+#include "utils/ConfigManager.h"
 
 class IconOnlyDelegate; // 前向声明，避免 IconOnlyDelegate.cpp 与 widget.h 循环包含
+class GroupSwitcherWidget; // Alt+` 同应用多窗口切换浮窗
 
 struct WindowGroup;
 
@@ -39,8 +41,6 @@ Q_DECLARE_METATYPE(WindowGroup) // for QVariant
 
 enum WidgetItemRole {
     WindowGroupRole = Qt::UserRole,
-    GroupWindowHandleRole,
-    GroupWindowLabelRole,
 };
 
 QT_BEGIN_NAMESPACE
@@ -86,11 +86,8 @@ public:
 private:
     bool forceShow();
     void showLabelForItem(QListWidgetItem* item, QString text = QString());
-    void setupLabelFont();
-    void restoreDefaultListWidgetLayout();
-    void syncGroupWindowLabels(const QString& exePath);
-    QString groupWindowLabel(const QString& exePath, HWND hwnd) const;
-    void showGroupSwitcherOverlay(); // Alt+` 组内切换浮窗
+    /// 重新加载 AppSwitcherStyle 并应用到 lw / delegate / label（首次以及 cfg 编辑后调用）
+    void reloadAppStyle();
     auto getLastActiveGroupWindow(const QString& exePath) -> QPair<HWND, QDateTime>;
     auto getLastValidActiveGroupWindow(const WindowGroup& group) -> QPair<HWND, QDateTime>;
     void sortGroupWindows(QList<HWND>& windows, const QString& exePath);
@@ -101,15 +98,14 @@ private:
 private:
     Ui::Widget* ui;
     QListWidget* lw = nullptr;
-    IconOnlyDelegate* itemDelegate = nullptr; // 存储指针以便动态切换模式
+    IconOnlyDelegate* itemDelegate = nullptr;
+    GroupSwitcherWidget* groupSwitcher = nullptr; // Alt+` 浮窗（独立顶层窗口）
+    AppSwitcherStyle m_appStyle;                  // 缓存当前 Alt+Tab 样式，避免每帧 paint 查询 INI
     const QMargins ListWidgetMargin{24, 24, 24, 24};
     /// exePath -> (HWND, time)
     QHash<QString, QHash<HWND, QDateTime>> winActiveOrder;
-    QHash<QString, QHash<HWND, int>> groupWindowLabels; // exePath -> (HWND, stable index)
-    QHash<QString, int> groupWindowNextLabel; // exePath -> next stable index
     QList<HWND> groupWindowOrder;  // for Alt+` 同组窗口切换
     int groupCurrentIndex = 0;     // Alt+` 当前选中窗口索引
-    bool isGroupSwitcherMode = false; // true 表示当前浮窗是 Alt+` 组内切换模式
 };
 
 

--- a/header/widget.h
+++ b/header/widget.h
@@ -6,6 +6,8 @@
 #include <QListWidget>
 #include <QDebug>
 
+class IconOnlyDelegate; // 前向声明，避免 IconOnlyDelegate.cpp 与 widget.h 循环包含
+
 struct WindowGroup;
 
 struct WindowInfo {
@@ -79,6 +81,7 @@ private:
     bool forceShow();
     void showLabelForItem(QListWidgetItem* item, QString text = QString());
     void setupLabelFont();
+    void showGroupSwitcherOverlay(); // Alt+` 组内切换浮窗
     auto getLastActiveGroupWindow(const QString& exePath) -> QPair<HWND, QDateTime>;
     auto getLastValidActiveGroupWindow(const WindowGroup& group) -> QPair<HWND, QDateTime>;
     void sortGroupWindows(QList<HWND>& windows, const QString& exePath);
@@ -89,10 +92,13 @@ private:
 private:
     Ui::Widget* ui;
     QListWidget* lw = nullptr;
+    IconOnlyDelegate* itemDelegate = nullptr; // 存储指针以便动态切换模式
     const QMargins ListWidgetMargin{24, 24, 24, 24};
     /// exePath -> (HWND, time)
     QHash<QString, QHash<HWND, QDateTime>> winActiveOrder;
-    QList<HWND> groupWindowOrder; // for Alt+` 同组窗口切换
+    QList<HWND> groupWindowOrder;  // for Alt+` 同组窗口切换
+    int groupCurrentIndex = 0;     // Alt+` 当前选中窗口索引
+    bool isGroupSwitcherMode = false; // true 表示当前浮窗是 Alt+` 组内切换模式
 };
 
 

--- a/header/widget.h
+++ b/header/widget.h
@@ -37,6 +37,12 @@ struct WindowGroup {
 
 Q_DECLARE_METATYPE(WindowGroup) // for QVariant
 
+enum WidgetItemRole {
+    WindowGroupRole = Qt::UserRole,
+    GroupWindowHandleRole,
+    GroupWindowLabelRole,
+};
+
 QT_BEGIN_NAMESPACE
 
 namespace Ui {
@@ -81,6 +87,9 @@ private:
     bool forceShow();
     void showLabelForItem(QListWidgetItem* item, QString text = QString());
     void setupLabelFont();
+    void restoreDefaultListWidgetLayout();
+    void syncGroupWindowLabels(const QString& exePath);
+    QString groupWindowLabel(const QString& exePath, HWND hwnd) const;
     void showGroupSwitcherOverlay(); // Alt+` 组内切换浮窗
     auto getLastActiveGroupWindow(const QString& exePath) -> QPair<HWND, QDateTime>;
     auto getLastValidActiveGroupWindow(const WindowGroup& group) -> QPair<HWND, QDateTime>;
@@ -96,6 +105,8 @@ private:
     const QMargins ListWidgetMargin{24, 24, 24, 24};
     /// exePath -> (HWND, time)
     QHash<QString, QHash<HWND, QDateTime>> winActiveOrder;
+    QHash<QString, QHash<HWND, int>> groupWindowLabels; // exePath -> (HWND, stable index)
+    QHash<QString, int> groupWindowNextLabel; // exePath -> next stable index
     QList<HWND> groupWindowOrder;  // for Alt+` 同组窗口切换
     int groupCurrentIndex = 0;     // Alt+` 当前选中窗口索引
     bool isGroupSwitcherMode = false; // true 表示当前浮窗是 Alt+` 组内切换模式

--- a/src/GroupSwitcherWidget.cpp
+++ b/src/GroupSwitcherWidget.cpp
@@ -1,0 +1,268 @@
+﻿#include "GroupSwitcherWidget.h"
+#include "utils/Util.h"
+#include "utils/setWindowBlur.h"
+#include "utils/QtWin.h"
+#include <QLabel>
+#include <QListWidget>
+#include <QScrollBar>
+#include <QStyledItemDelegate>
+#include <QPainter>
+#include <QFontMetrics>
+#include <QScreen>
+#include <QGuiApplication>
+#include <QApplication>
+#include <QCursor>
+
+// ── GroupItemDelegate：仅绘制文字 + 选中态背景 ────────────────────────────
+class GroupItemDelegate : public QStyledItemDelegate {
+public:
+    GroupSwitcherStyle style;
+
+    explicit GroupItemDelegate(QObject* parent) : QStyledItemDelegate(parent) {}
+
+    void paint(QPainter* painter, const QStyleOptionViewItem& option, const QModelIndex& index) const override {
+        painter->setRenderHint(QPainter::Antialiasing);
+        painter->setPen(Qt::NoPen);
+
+        // 除最后一项外，其他 item 的 sizeHint 包含了一个 itemSpacing 的尾部预留，
+        // 需要在可见区域（itemHeight）内绘制背景与文字，避免选中态背景染色到间隔槽。
+        const int rows = index.model() ? index.model()->rowCount() : 0;
+        const bool isLast = (index.row() == rows - 1);
+        const int trailing = isLast ? 0 : style.itemSpacing;
+        const QRect visibleRect = option.rect.adjusted(0, 0, 0, -trailing);
+
+        const bool selected = option.state & QStyle::State_Selected;
+        const QColor bg = selected ? style.selectedItemBg : style.itemBackground;
+        if (bg.alpha() > 0) {
+            painter->setBrush(bg);
+            painter->drawRoundedRect(visibleRect, style.borderRadius, style.borderRadius);
+        }
+
+        const QRect textRect = visibleRect.adjusted(
+            style.itemPadding.left(), style.itemPadding.top(),
+            -style.itemPadding.right(), -style.itemPadding.bottom()
+        );
+
+        QFont font(style.fontFamily);
+        font.setPointSize(style.fontSize);
+        painter->setFont(font);
+        painter->setPen(selected ? style.selectedTextColor : style.textColor);
+
+        const QFontMetrics fm(font);
+        const auto raw = index.data(Qt::DisplayRole).toString();
+        const auto elided = fm.elidedText(raw, Qt::ElideRight, textRect.width());
+        painter->drawText(textRect, Qt::AlignVCenter | Qt::AlignLeft, elided);
+    }
+
+    QSize sizeHint(const QStyleOptionViewItem&, const QModelIndex&) const override {
+        return {0, style.itemHeight}; // 高度仅作 fallback；GroupSwitcherWidget 会逐项 setSizeHint 覆盖
+    }
+};
+
+// ── GroupSwitcherWidget ──────────────────────────────────────────────────
+GroupSwitcherWidget::GroupSwitcherWidget(QWidget* parent) : QWidget(parent) {
+    // 不抢占焦点：键盘事件由 Widget（KeyboardHooker receiver）统一处理
+    setWindowFlag(Qt::FramelessWindowHint);
+    setWindowFlag(Qt::WindowStaysOnTopHint);
+    setWindowFlag(Qt::Tool);
+    setWindowFlag(Qt::WindowDoesNotAcceptFocus);
+    setAttribute(Qt::WA_TranslucentBackground);
+    setAttribute(Qt::WA_ShowWithoutActivating);
+    setFocusPolicy(Qt::NoFocus);
+    setWindowTitle("AltTaber GroupSwitcher");
+    QtWin::taskbarDeleteTab(this); // 删除任务栏图标
+
+    m_iconLabel = new QLabel(this);
+    m_iconLabel->setAlignment(Qt::AlignCenter);
+    m_iconLabel->setAttribute(Qt::WA_TranslucentBackground);
+    m_iconLabel->setStyleSheet("background: transparent;");
+
+    m_listWidget = new QListWidget(this);
+    m_listWidget->setFocusPolicy(Qt::NoFocus);
+    m_listWidget->setSelectionMode(QAbstractItemView::SingleSelection);
+    m_listWidget->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+    m_listWidget->setUniformItemSizes(false); // 最后一项 sizeHint 与其他不同，必须禁用 uniform
+    m_listWidget->setSpacing(0);              // spacing 直接放到每项 sizeHint 尾部，以便精确控制总高度
+    // 是否启用滚动、是否启用自动滚动与垂直滚动条策略，在 recomputeGeometry 中根据 maxVisibleItems 动态切换
+    m_listWidget->setStyleSheet(R"(
+        QListWidget {
+            background-color: transparent;
+            border: none;
+            outline: none;
+        }
+        QScrollBar:vertical {
+            background: transparent;
+            width: 8px;
+            margin: 2px 0;
+        }
+        QScrollBar::handle:vertical {
+            background: rgba(255, 255, 255, 80);
+            border-radius: 3px;
+            min-height: 24px;
+        }
+        QScrollBar::handle:vertical:hover {
+            background: rgba(255, 255, 255, 140);
+        }
+        QScrollBar::add-line:vertical, QScrollBar::sub-line:vertical {
+            height: 0;
+            background: transparent;
+        }
+        QScrollBar::add-page:vertical, QScrollBar::sub-page:vertical {
+            background: transparent;
+        }
+    )");
+
+    m_delegate = new GroupItemDelegate(m_listWidget);
+    m_listWidget->setItemDelegate(m_delegate);
+
+    // 配置热重载：notepad 关闭后重新加载样式并重排
+    connect(&cfg, &ConfigManager::configEdited, this, [this] {
+        reloadStyle();
+        if (isVisible()) recomputeGeometry();
+    });
+
+    reloadStyle();
+}
+
+void GroupSwitcherWidget::reloadStyle() {
+    m_style = cfg.loadGroupStyle();
+    m_delegate->style = m_style;
+    if (m_listWidget) m_listWidget->viewport()->update();
+}
+
+void GroupSwitcherWidget::showFor(const QList<HWND>& windows, int currentIndex,
+                                  const QIcon& appIcon, const QString& exePath) {
+    m_windows = windows;
+    m_exePath = exePath;
+    m_appIcon = appIcon;
+
+    rebuildItems();
+    setCurrentIndex(currentIndex);
+    recomputeGeometry();
+    positionOnScreen();
+
+    if (!isVisible()) show();
+    raise(); // 保持在最上层
+}
+
+void GroupSwitcherWidget::rebuildItems() {
+    m_listWidget->clear();
+    for (HWND hwnd: m_windows) {
+        auto title = Util::getWindowTitle(hwnd);
+        if (title.isEmpty()) title = QStringLiteral("(无标题窗口)");
+        m_listWidget->addItem(title);
+    }
+}
+
+void GroupSwitcherWidget::setCurrentIndex(int idx) {
+    if (idx < 0 || idx >= m_windows.size()) return;
+    m_listWidget->setCurrentRow(idx);
+}
+
+int GroupSwitcherWidget::currentIndex() const {
+    return m_listWidget ? m_listWidget->currentRow() : -1;
+}
+
+HWND GroupSwitcherWidget::currentHwnd() const {
+    const int i = currentIndex();
+    return (i >= 0 && i < m_windows.size()) ? m_windows.at(i) : nullptr;
+}
+
+void GroupSwitcherWidget::recomputeGeometry() {
+    const int N = m_windows.size();
+    if (N == 0) return;
+
+    // 顶部图标区
+    const int iconAreaW = m_style.iconSize + m_style.iconPadding.left() + m_style.iconPadding.right();
+    const int iconAreaH = m_style.iconSize + m_style.iconPadding.top() + m_style.iconPadding.bottom();
+
+    // 列表内容宽度 = max(itemMinWidth, 最长标题 + itemPadding)
+    QFont measureFont(m_style.fontFamily);
+    measureFont.setPointSize(m_style.fontSize);
+    const QFontMetrics fm(measureFont);
+    int maxTextW = 0;
+    for (HWND hwnd: m_windows) {
+        auto t = Util::getWindowTitle(hwnd);
+        if (t.isEmpty()) t = QStringLiteral("(无标题窗口)");
+        maxTextW = std::max(maxTextW, fm.horizontalAdvance(t));
+    }
+    const int itemHorizPad = m_style.itemPadding.left() + m_style.itemPadding.right();
+    int contentW = std::max({m_style.itemMinWidth, maxTextW + itemHorizPad, iconAreaW});
+
+    // 是否需要滚动：当条目数 > maxVisibleItems 时，列表高度限制为 maxVisibleItems 行，滚动查看其余
+    // 注：使用 qMin/qMax 避免与 windows.h 的 min/max 宏冲突
+    const int visibleRows = qMin(N, m_style.maxVisibleItems);
+    const bool needsScroll = (N > m_style.maxVisibleItems);
+    const int listInnerH = visibleRows * m_style.itemHeight + qMax(0, visibleRows - 1) * m_style.itemSpacing;
+
+    // 动态切换滚动策略：仅在需要时启用 autoScroll + 垂直滚动条
+    m_listWidget->setAutoScroll(needsScroll);
+    m_listWidget->setVerticalScrollBarPolicy(
+        needsScroll ? Qt::ScrollBarAlwaysOn : Qt::ScrollBarAlwaysOff);
+    if (needsScroll) {
+        // 为滚动条预留宽度（与 stylesheet 中 width: 8px + margin 保持一致）
+        const int scrollBarW = m_listWidget->verticalScrollBar()->sizeHint().width();
+        contentW += qMax(scrollBarW, 10);
+    }
+
+    // 外边距：复用 itemPadding 的 LR/B 作为列表整体边距，顶部紧贴图标区
+    const int outerL = m_style.itemPadding.left();
+    const int outerR = m_style.itemPadding.right();
+    const int outerB = m_style.itemPadding.bottom();
+
+    const int totalW = std::max(contentW + outerL + outerR, iconAreaW);
+    const int totalH = iconAreaH + listInnerH + outerB;
+
+    // 应用尺寸
+    setFixedSize(totalW, totalH);
+
+    // 顶部图标 Label
+    const QPixmap iconPix = m_appIcon.pixmap({m_style.iconSize, m_style.iconSize});
+    m_iconLabel->setPixmap(iconPix);
+    m_iconLabel->setGeometry((totalW - iconAreaW) / 2, 0, iconAreaW, iconAreaH);
+
+    // 列表
+    const int listX = (totalW - contentW) / 2;
+    const int listY = iconAreaH;
+    m_listWidget->setGeometry(listX, listY, contentW, listInnerH);
+    // 将 itemSpacing 直接包含在除最后一项外的 sizeHint 中，
+    // 让 QListWidget 不需依赖其 spacing 机制，总高度与实际占用严格匹配。
+    // 需要插入滚动条的列表项 宽度要扣除滚动条宽以避免水平溶出
+    const int rows = m_listWidget->count();
+    const int itemContentW = needsScroll
+                                 ? contentW - m_listWidget->verticalScrollBar()->sizeHint().width()
+                                 : contentW;
+    for (int i = 0; i < rows; i++) {
+        const int h = (i < rows - 1) ? (m_style.itemHeight + m_style.itemSpacing) : m_style.itemHeight;
+        m_listWidget->item(i)->setSizeHint({itemContentW, h});
+    }
+    m_listWidget->viewport()->update();
+}
+
+void GroupSwitcherWidget::positionOnScreen() {
+    const bool displayOnPrimary = (cfg.getDisplayMonitor() == PrimaryMonitor);
+    auto* screen = displayOnPrimary
+                       ? QGuiApplication::primaryScreen()
+                       : QGuiApplication::screenAt(QCursor::pos());
+    if (!screen) screen = QGuiApplication::primaryScreen();
+    if (!screen) return;
+
+    auto rect = this->rect();
+    rect.moveCenter(screen->geometry().center());
+    setGeometry(rect);
+}
+
+void GroupSwitcherWidget::showEvent(QShowEvent* event) {
+    QWidget::showEvent(event);
+    // 这两个 API 需要 native window，必须在 winId() 之后调用
+    Util::setWindowRoundCorner(hWnd());
+    setWindowBlur(hWnd());
+}
+
+void GroupSwitcherWidget::paintEvent(QPaintEvent*) {
+    QPainter painter(this);
+    painter.setRenderHint(QPainter::Antialiasing);
+    painter.setPen(Qt::NoPen);
+    painter.setBrush(m_style.backgroundColor);
+    painter.drawRect(this->rect());
+}

--- a/src/utils/IconOnlyDelegate.cpp
+++ b/src/utils/IconOnlyDelegate.cpp
@@ -6,87 +6,44 @@ void IconOnlyDelegate::paint(QPainter* painter, const QStyleOptionViewItem& opti
     painter->setRenderHint(QPainter::Antialiasing);
     painter->setPen(Qt::NoPen); //取消边框
 
-    // 选中 / 悬停背景（两种模式共用）
+    // 选中 / 悬停背景
     if (option.state & QStyle::State_Selected) {
-        painter->setBrush(selectedColor);
-        painter->drawRoundedRect(option.rect, radius, radius);
+        painter->setBrush(m_style.selectedColor);
+        painter->drawRoundedRect(option.rect, m_style.borderRadius, m_style.borderRadius);
     } else if (option.state & QStyle::State_MouseOver) {
-        painter->setBrush(hoverColor);
-        painter->drawRoundedRect(option.rect, radius, radius);
+        painter->setBrush(m_style.hoverColor);
+        painter->drawRoundedRect(option.rect, m_style.borderRadius, m_style.borderRadius);
     }
 
-    if (m_groupSwitcherMode) {
-        // ── 组内切换模式 ──────────────────────────────────────
-        // 布局：[上 20px "窗口 N"] [中 图标] [下 18px 窗口标题]
-        constexpr int topH = 20;
-        constexpr int botH = 18;
-        constexpr int textMargin = 6;
-        const int iconAreaH = option.rect.height() - topH - botH;
-
-        // 上方：显示"窗口 N"
-        QFont numFont("Microsoft YaHei UI");
-        numFont.setPointSizeF(8.5);
-        numFont.setBold(true);
-        painter->setFont(numFont);
-        painter->setPen(Qt::white);
-        QRect topRect(option.rect.left() + textMargin, option.rect.top(),
-                      option.rect.width() - 2 * textMargin, topH);
-        painter->drawText(topRect, Qt::AlignCenter, index.data(GroupWindowLabelRole).toString());
-
-        // 中间：图标
-        auto icon = qvariant_cast<QIcon>(index.data(Qt::DecorationRole));
-        if (!icon.isNull()) {
-            QRect iconArea(option.rect.left(), option.rect.top() + topH,
-                           option.rect.width(), iconAreaH);
-            QRect iconRect{{}, option.decorationSize};
-            iconRect.moveCenter(iconArea.center());
-            icon.paint(painter, iconRect);
-        }
-
-        // 下方：窗口标题（无标题则不显示）
-        auto group = qvariant_cast<WindowGroup>(index.data(WindowGroupRole));
-        auto title = group.windows.isEmpty() ? QString() : group.windows.first().title;
-        if (!title.isEmpty()) {
-            QFont titleFont("Microsoft YaHei UI");
-            titleFont.setPointSizeF(8.0);
-            painter->setFont(titleFont);
-            painter->setPen(Qt::white);
-            QRect botRect(option.rect.left() + textMargin, option.rect.top() + option.rect.height() - botH,
-                          option.rect.width() - 2 * textMargin, botH);
-            QFontMetrics fm(titleFont);
-            auto elidedText = fm.elidedText(title, Qt::ElideRight, botRect.width());
-            painter->drawText(botRect, Qt::AlignCenter, elidedText);
-        }
-        return;
-    }
-
-    // ── 普通模式（Alt+Tab）────────────────────────────────────
-    // 居中绘制图标
+    // 图标：按 iconPadding 定位（支持非对称 padding）
     auto icon = qvariant_cast<QIcon>(index.data(Qt::DecorationRole));
     if (!icon.isNull()) {
-        QRect iconRect{{}, option.decorationSize}; // QListWidget::iconSize()
-        iconRect.moveCenter(option.rect.center());
+        const QRect iconRect(
+            option.rect.left() + m_style.iconPadding.left(),
+            option.rect.top() + m_style.iconPadding.top(),
+            m_style.iconSize,
+            m_style.iconSize
+        );
         icon.paint(painter, iconRect);
     }
 
-    // draw badge
+    // Badge: 当应用有多个窗口时，右上角显示窗口数
     auto num = qvariant_cast<WindowGroup>(index.data(WindowGroupRole)).windows.size();
     if (num > 1) {
-        auto text = QString::number(num);
+        const auto text = QString::number(num);
         const auto extraWidth = 8 * (text.size() - 1);
         constexpr auto R = 12;
-        auto badgeCenter = option.rect.topRight() + QPoint(-(R + 3), R + 3);
-        // extra Width for extra number
-        auto badgeRect = QRect(badgeCenter + QPoint(-R - extraWidth, -R), QSize(2 * R + extraWidth, 2 * R));
-        painter->setPen(QColor(200, 200, 200, 50));
-        painter->setBrush(QColor(133, 114, 97)); // learn from iOS
+        const auto badgeCenter = option.rect.topRight() + QPoint(-(R + 3), R + 3);
+        const auto badgeRect = QRect(badgeCenter + QPoint(-R - extraWidth, -R), QSize(2 * R + extraWidth, 2 * R));
+        painter->setPen(m_style.badgeBorder);
+        painter->setBrush(m_style.badgeBg);
         painter->drawRoundedRect(badgeRect, R, R);
 
         QFont font{"Microsoft YaHei"};
-        font.setPointSizeF(12.8);
+        font.setPointSizeF(m_style.badgeFontSize);
         font.setBold(true);
         painter->setFont(font);
-        painter->setPen(QColor(214, 192, 171));
+        painter->setPen(m_style.badgeText);
         painter->drawText(badgeRect, Qt::AlignCenter, text);
     }
 }

--- a/src/utils/IconOnlyDelegate.cpp
+++ b/src/utils/IconOnlyDelegate.cpp
@@ -17,18 +17,21 @@ void IconOnlyDelegate::paint(QPainter* painter, const QStyleOptionViewItem& opti
 
     if (m_groupSwitcherMode) {
         // ── 组内切换模式 ──────────────────────────────────────
-        // 布局：[上 18px "窗口 N"] [中 图标] [下 16px 窗口标题]
-        constexpr int topH = 18;
-        constexpr int botH = 16;
+        // 布局：[上 20px "窗口 N"] [中 图标] [下 18px 窗口标题]
+        constexpr int topH = 20;
+        constexpr int botH = 18;
+        constexpr int textMargin = 6;
         const int iconAreaH = option.rect.height() - topH - botH;
 
         // 上方：显示"窗口 N"
-        QFont numFont("Microsoft YaHei");
-        numFont.setPointSizeF(8.0);
+        QFont numFont("Microsoft YaHei UI");
+        numFont.setPointSizeF(8.5);
+        numFont.setBold(true);
         painter->setFont(numFont);
-        painter->setPen(QColor(180, 180, 180, 220));
-        QRect topRect(option.rect.left(), option.rect.top(), option.rect.width(), topH);
-        painter->drawText(topRect, Qt::AlignCenter, QString("窗口 %1").arg(index.row() + 1));
+        painter->setPen(Qt::white);
+        QRect topRect(option.rect.left() + textMargin, option.rect.top(),
+                      option.rect.width() - 2 * textMargin, topH);
+        painter->drawText(topRect, Qt::AlignCenter, index.data(GroupWindowLabelRole).toString());
 
         // 中间：图标
         auto icon = qvariant_cast<QIcon>(index.data(Qt::DecorationRole));
@@ -41,15 +44,15 @@ void IconOnlyDelegate::paint(QPainter* painter, const QStyleOptionViewItem& opti
         }
 
         // 下方：窗口标题（无标题则不显示）
-        auto group = qvariant_cast<WindowGroup>(index.data(Qt::UserRole));
+        auto group = qvariant_cast<WindowGroup>(index.data(WindowGroupRole));
         auto title = group.windows.isEmpty() ? QString() : group.windows.first().title;
         if (!title.isEmpty()) {
-            QFont titleFont("Microsoft YaHei");
-            titleFont.setPointSizeF(7.5);
+            QFont titleFont("Microsoft YaHei UI");
+            titleFont.setPointSizeF(8.0);
             painter->setFont(titleFont);
-            painter->setPen(QColor(200, 200, 200, 160));
-            QRect botRect(option.rect.left() + 2, option.rect.bottom() - botH,
-                          option.rect.width() - 4, botH);
+            painter->setPen(Qt::white);
+            QRect botRect(option.rect.left() + textMargin, option.rect.top() + option.rect.height() - botH,
+                          option.rect.width() - 2 * textMargin, botH);
             QFontMetrics fm(titleFont);
             auto elidedText = fm.elidedText(title, Qt::ElideRight, botRect.width());
             painter->drawText(botRect, Qt::AlignCenter, elidedText);
@@ -67,7 +70,7 @@ void IconOnlyDelegate::paint(QPainter* painter, const QStyleOptionViewItem& opti
     }
 
     // draw badge
-    auto num = qvariant_cast<WindowGroup>(index.data(Qt::UserRole)).windows.size();
+    auto num = qvariant_cast<WindowGroup>(index.data(WindowGroupRole)).windows.size();
     if (num > 1) {
         auto text = QString::number(num);
         const auto extraWidth = 8 * (text.size() - 1);

--- a/src/utils/IconOnlyDelegate.cpp
+++ b/src/utils/IconOnlyDelegate.cpp
@@ -1,10 +1,12 @@
 ﻿#include "utils/IconOnlyDelegate.h"
 #include "widget.h"
+#include <QFontMetrics>
 
 void IconOnlyDelegate::paint(QPainter* painter, const QStyleOptionViewItem& option, const QModelIndex& index) const {
     painter->setRenderHint(QPainter::Antialiasing);
     painter->setPen(Qt::NoPen); //取消边框
-    // option.rect.size() == QListWidgetItem::sizeHint()
+
+    // 选中 / 悬停背景（两种模式共用）
     if (option.state & QStyle::State_Selected) {
         painter->setBrush(selectedColor);
         painter->drawRoundedRect(option.rect, radius, radius);
@@ -13,6 +15,49 @@ void IconOnlyDelegate::paint(QPainter* painter, const QStyleOptionViewItem& opti
         painter->drawRoundedRect(option.rect, radius, radius);
     }
 
+    if (m_groupSwitcherMode) {
+        // ── 组内切换模式 ──────────────────────────────────────
+        // 布局：[上 18px "窗口 N"] [中 图标] [下 16px 窗口标题]
+        constexpr int topH = 18;
+        constexpr int botH = 16;
+        const int iconAreaH = option.rect.height() - topH - botH;
+
+        // 上方：显示"窗口 N"
+        QFont numFont("Microsoft YaHei");
+        numFont.setPointSizeF(8.0);
+        painter->setFont(numFont);
+        painter->setPen(QColor(180, 180, 180, 220));
+        QRect topRect(option.rect.left(), option.rect.top(), option.rect.width(), topH);
+        painter->drawText(topRect, Qt::AlignCenter, QString("窗口 %1").arg(index.row() + 1));
+
+        // 中间：图标
+        auto icon = qvariant_cast<QIcon>(index.data(Qt::DecorationRole));
+        if (!icon.isNull()) {
+            QRect iconArea(option.rect.left(), option.rect.top() + topH,
+                           option.rect.width(), iconAreaH);
+            QRect iconRect{{}, option.decorationSize};
+            iconRect.moveCenter(iconArea.center());
+            icon.paint(painter, iconRect);
+        }
+
+        // 下方：窗口标题（无标题则不显示）
+        auto group = qvariant_cast<WindowGroup>(index.data(Qt::UserRole));
+        auto title = group.windows.isEmpty() ? QString() : group.windows.first().title;
+        if (!title.isEmpty()) {
+            QFont titleFont("Microsoft YaHei");
+            titleFont.setPointSizeF(7.5);
+            painter->setFont(titleFont);
+            painter->setPen(QColor(200, 200, 200, 160));
+            QRect botRect(option.rect.left() + 2, option.rect.bottom() - botH,
+                          option.rect.width() - 4, botH);
+            QFontMetrics fm(titleFont);
+            auto elidedText = fm.elidedText(title, Qt::ElideRight, botRect.width());
+            painter->drawText(botRect, Qt::AlignCenter, elidedText);
+        }
+        return;
+    }
+
+    // ── 普通模式（Alt+Tab）────────────────────────────────────
     // 居中绘制图标
     auto icon = qvariant_cast<QIcon>(index.data(Qt::DecorationRole));
     if (!icon.isNull()) {

--- a/src/widget.cpp
+++ b/src/widget.cpp
@@ -15,6 +15,7 @@
 #include <QMetaEnum>
 #include "utils/SystemTray.h"
 #include "utils/ConfigManager.h"
+#include <QSet>
 
 Widget::Widget(QWidget* parent) : QWidget(parent), ui(new Ui::Widget) {
     ui->setupUi(this);
@@ -59,12 +60,11 @@ Widget::Widget(QWidget* parent) : QWidget(parent), ui(new Ui::Widget) {
         if (!cur) return;
         if (isGroupSwitcherMode) {
             // 组内切换模式：显示具体窗口标题
-            int row = lw->row(cur);
-            if (row >= 0 && row < groupWindowOrder.size()) {
-                auto title = Util::getWindowTitle(groupWindowOrder[row]);
-                if (title.isEmpty()) title = QString("窗口 %1").arg(row + 1);
-                showLabelForItem(cur, title);
-            }
+            const auto hwndValue = cur->data(GroupWindowHandleRole).toULongLong();
+            auto hwnd = reinterpret_cast<HWND>(static_cast<quintptr>(hwndValue));
+            auto title = hwnd ? Util::getWindowTitle(hwnd) : QString();
+            if (title.isEmpty()) title = cur->data(GroupWindowLabelRole).toString();
+            showLabelForItem(cur, title);
         } else {
             showLabelForItem(cur);
         }
@@ -113,6 +113,7 @@ void Widget::keyPressEvent(QKeyEvent* event) {
         // 首次按下：构建同组窗口列表，并定位当前窗口在列表中的索引
         if (groupWindowOrder.isEmpty()) {
             auto targetExe = Util::getWindowProcessPath(foreWin);
+            syncGroupWindowLabels(targetExe);
             groupWindowOrder = buildGroupWindowOrder(targetExe);
             groupCurrentIndex = 0;
             for (int i = 0; i < groupWindowOrder.size(); i++) {
@@ -167,7 +168,7 @@ void Widget::showLabelForItem(QListWidgetItem* item, QString text) {
     if (!item) return;
 
     if (text.isNull()) {
-        auto path = item->data(Qt::UserRole).value<WindowGroup>().exePath;
+        auto path = item->data(WindowGroupRole).value<WindowGroup>().exePath;
         text = Util::getFileDescription(path);
     }
     ui->label->setText(text);
@@ -205,14 +206,50 @@ void Widget::setupLabelFont() {
     });
 }
 
+void Widget::restoreDefaultListWidgetLayout() {
+    itemDelegate->setGroupSwitcherMode(false);
+    lw->setGridSize({80, 80});
+    lw->setFixedHeight(lw->gridSize().height());
+}
+
+void Widget::syncGroupWindowLabels(const QString& exePath) {
+    if (exePath.isEmpty()) return;
+
+    const auto windows = Util::listValidWindows(exePath); // 用首次扫描到的顺序固定命名，避免随活跃顺序跳动
+    auto& labelMap = groupWindowLabels[exePath];
+    auto& nextLabel = groupWindowNextLabel[exePath];
+    if (nextLabel < 1)
+        nextLabel = 1;
+
+    const QSet<HWND> activeWindows(windows.begin(), windows.end());
+    for (auto it = labelMap.begin(); it != labelMap.end();) {
+        if (activeWindows.contains(it.key()))
+            ++it;
+        else
+            it = labelMap.erase(it);
+    }
+
+    for (HWND hwnd: windows) {
+        if (!labelMap.contains(hwnd))
+            labelMap.insert(hwnd, nextLabel++);
+    }
+}
+
+QString Widget::groupWindowLabel(const QString& exePath, HWND hwnd) const {
+    if (!hwnd) return {};
+
+    const auto labelIndex = groupWindowLabels.value(exePath).value(hwnd);
+    return labelIndex > 0 ? QString("窗口 %1").arg(labelIndex) : QString();
+}
+
 void Widget::keyReleaseEvent(QKeyEvent* event) {
     if (event->key() == Qt::Key_Alt) {
         if (this->isVisible()) {
             if (isGroupSwitcherMode) {
                 // Alt+` 组内切换模式：直接切换到当前选中行对应的窗口
-                int row = lw->currentRow();
-                if (row >= 0 && row < groupWindowOrder.size()) {
-                    HWND hwnd = groupWindowOrder[row];
+                if (auto item = lw->currentItem()) {
+                    const auto hwndValue = item->data(GroupWindowHandleRole).toULongLong();
+                    auto hwnd = reinterpret_cast<HWND>(static_cast<quintptr>(hwndValue));
                     if (hwnd) {
                         Util::switchToWindow(hwnd);
                         qInfo() << "(Alt+`)Switch to" << Util::getWindowTitle(hwnd);
@@ -221,7 +258,7 @@ void Widget::keyReleaseEvent(QKeyEvent* event) {
             } else {
                 // Alt+Tab 模式：原有逻辑，切换到该应用组最后活跃的窗口
                 if (auto item = lw->currentItem()) {
-                    if (auto group = item->data(Qt::UserRole).value<WindowGroup>(); !group.windows.empty()) {
+                    if (auto group = item->data(WindowGroupRole).value<WindowGroup>(); !group.windows.empty()) {
                         WindowInfo targetWin = group.windows.at(0); // TODO 需要排序（lastActiveWindow 被关闭情况下）
                         const auto lastActive = getLastActiveGroupWindow(group.exePath).first;
                         for (auto& info: group.windows) {
@@ -243,10 +280,7 @@ void Widget::keyReleaseEvent(QKeyEvent* event) {
         groupWindowOrder.clear();
         groupCurrentIndex = 0;
         isGroupSwitcherMode = false;
-        // 恢复 Alt+Tab 模式的格子尺寸和委托模式
-        itemDelegate->setGroupSwitcherMode(false);
-        lw->setGridSize({80, 80});
-        lw->setFixedHeight(80);
+        restoreDefaultListWidgetLayout();
     }
     QWidget::keyReleaseEvent(event);
 }
@@ -315,7 +349,7 @@ bool Widget::prepareListWidget() {
     lw->clear();
     for (auto& winGroup: winGroupList) {
         auto item = new QListWidgetItem(winGroup.icon, {}); // null != "", which will completely hide text area
-        item->setData(Qt::UserRole, QVariant::fromValue(winGroup));
+        item->setData(WindowGroupRole, QVariant::fromValue(winGroup));
         item->setSizeHint(lw->gridSize()); // 决定了delegate的绘制区域，比grid小的话，paintRect就不居中了，而且update也不及时
 //        item->setFlags(item->flags() & ~Qt::ItemIsSelectable); // 不可选中
         lw->addItem(item);
@@ -406,10 +440,11 @@ void Widget::showGroupSwitcherOverlay() {
         if (groupWindowOrder.isEmpty()) return;
 
         // 启用组切换模式：图标格高度增加以容纳上下文字
-        // 布局：18px"窗口 N" + 64px 图标 + 16px 标题 + 12px 边距 = 110px
+        // 布局：更宽的格子 + 上下文字，避免图标过挤且标题被过早截断
+        constexpr int GroupGridW = 124;
         constexpr int GroupGridH = 110;
         itemDelegate->setGroupSwitcherMode(true);
-        lw->setGridSize({80, GroupGridH});
+        lw->setGridSize({GroupGridW, GroupGridH});
         lw->setFixedHeight(GroupGridH);
 
         auto firstHwnd = groupWindowOrder.first();
@@ -428,7 +463,12 @@ void Widget::showGroupSwitcherOverlay() {
             singleGroup.addWindow({title, Util::getClassName(hwnd), hwnd});
 
             auto* item = new QListWidgetItem(appIcon, {});
-            item->setData(Qt::UserRole, QVariant::fromValue(singleGroup));
+            item->setData(WindowGroupRole, QVariant::fromValue(singleGroup));
+            item->setData(GroupWindowHandleRole, static_cast<qulonglong>(reinterpret_cast<quintptr>(hwnd)));
+            auto label = groupWindowLabel(appPath, hwnd);
+            if (label.isEmpty())
+                label = QString("窗口 %1").arg(i + 1);
+            item->setData(GroupWindowLabelRole, label);
             item->setSizeHint(lw->gridSize());
             lw->addItem(item);
         }
@@ -516,7 +556,7 @@ bool Widget::eventFilter(QObject* watched, QEvent* event) {
         if (auto item = lw->itemAt(cursorPos)) {
             if (lw->currentItem() != item)
                 lw->setCurrentItem(item);
-            auto windowGroup = item->data(Qt::UserRole).value<WindowGroup>();
+            auto windowGroup = item->data(WindowGroupRole).value<WindowGroup>();
             if (windowGroup.windows.isEmpty()) return false;
 
             static QListWidgetItem* lastItem = nullptr;

--- a/src/widget.cpp
+++ b/src/widget.cpp
@@ -15,6 +15,7 @@
 #include <QMetaEnum>
 #include "utils/SystemTray.h"
 #include "utils/ConfigManager.h"
+#include "GroupSwitcherWidget.h"
 #include <QSet>
 
 Widget::Widget(QWidget* parent) : QWidget(parent), ui(new Ui::Widget) {
@@ -29,17 +30,12 @@ Widget::Widget(QWidget* parent) : QWidget(parent), ui(new Ui::Widget) {
     Util::setWindowRoundCorner(this->hWnd()); // 设置窗口圆角
     setWindowBlur(hWnd()); // 设置窗口模糊, 必须配合Qt::WA_TranslucentBackground
 
-    setupLabelFont();
-
     lw->setViewMode(QListView::IconMode);
     lw->setMovement(QListView::Static);
     lw->setFlow(QListView::LeftToRight);
     lw->setWrapping(false);
     lw->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
     lw->setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
-    lw->setIconSize({64, 64});
-    lw->setGridSize({80, 80});
-    lw->setFixedHeight(lw->gridSize().height());
     lw->setUniformItemSizes(true); // optimization ?
     lw->setStyleSheet(R"(
         QListWidget {
@@ -56,18 +52,16 @@ Widget::Widget(QWidget* parent) : QWidget(parent), ui(new Ui::Widget) {
     lw->setItemDelegate(itemDelegate);
     lw->installEventFilter(this);
 
+    // 创建 Alt+` 组内切换浮窗（独立顶层窗口；不抢占焦点）
+    groupSwitcher = new GroupSwitcherWidget;
+
+    // 加载 AppSwitcherStyle（含字体/图标尺寸/网格尺寸/颜色等），并接 cfg 热重载
+    reloadAppStyle();
+    connect(&cfg, &ConfigManager::configEdited, this, &Widget::reloadAppStyle);
+
     connect(lw, &QListWidget::currentItemChanged, this, [this](QListWidgetItem* cur, QListWidgetItem*) {
         if (!cur) return;
-        if (isGroupSwitcherMode) {
-            // 组内切换模式：显示具体窗口标题
-            const auto hwndValue = cur->data(GroupWindowHandleRole).toULongLong();
-            auto hwnd = reinterpret_cast<HWND>(static_cast<quintptr>(hwndValue));
-            auto title = hwnd ? Util::getWindowTitle(hwnd) : QString();
-            if (title.isEmpty()) title = cur->data(GroupWindowLabelRole).toString();
-            showLabelForItem(cur, title);
-        } else {
-            showLabelForItem(cur);
-        }
+        showLabelForItem(cur);
     });
 
     connect(qApp, &QApplication::focusWindowChanged, this, [this](QWindow* focusWindow) {
@@ -101,27 +95,43 @@ void Widget::keyPressEvent(QKeyEvent* event) {
         auto index = (i - (2 * isShiftPressed - 1) + lw->count()) % lw->count();
         lw->setCurrentRow(index);
     } else if (key == Qt::Key_QuoteLeft && (modifiers & Qt::AltModifier)) { // Alt + `, 在前台窗口同组窗口内切换
-        // 如果当前显示的是 Alt+Tab 列表（非组内切换模式），则直接隐藏
-        if (this->isVisible() && !this->isMinimized() && !isGroupSwitcherMode) {
-            hide();
-            return;
-        }
-
         auto foreWin = GetForegroundWindow();
-        bool shiftPressed = modifiers & Qt::ShiftModifier;
+        const bool shiftPressed = modifiers & Qt::ShiftModifier;
 
-        // 首次按下：构建同组窗口列表，并定位当前窗口在列表中的索引
-        if (groupWindowOrder.isEmpty()) {
-            auto targetExe = Util::getWindowProcessPath(foreWin);
-            syncGroupWindowLabels(targetExe);
-            groupWindowOrder = buildGroupWindowOrder(targetExe);
-            groupCurrentIndex = 0;
-            for (int i = 0; i < groupWindowOrder.size(); i++) {
-                if (groupWindowOrder[i] == foreWin) {
-                    groupCurrentIndex = i;
-                    break;
+        QIcon appIcon;
+        QString appPath;
+        HWND seedWin = foreWin; // 用于定位 currentIndex 的「种子窗口」
+
+        // 模式互斥：若 Alt+Tab 列表正在显示，隐藏它并以其选中应用作为 Alt+` 的切换基准
+        if (this->isVisible() && !this->isMinimized()) {
+            if (auto item = lw->currentItem()) {
+                auto group = item->data(WindowGroupRole).value<WindowGroup>();
+                if (!group.exePath.isEmpty()) {
+                    appPath = group.exePath;
+                    appIcon = group.icon;
+                    groupWindowOrder.clear(); // 使用选中应用重新构建
+                    groupCurrentIndex = 0;
+                    seedWin = nullptr; // 不再以前台窗口作为定位种子
                 }
             }
+            hide();
+        }
+
+        // 首次按下（或刚从 Alt+Tab 切过来）：构建同组窗口列表
+        if (groupWindowOrder.isEmpty()) {
+            if (appPath.isEmpty()) appPath = Util::getWindowProcessPath(foreWin);
+            groupWindowOrder = buildGroupWindowOrder(appPath);
+            groupCurrentIndex = 0;
+            if (seedWin) {
+                for (int i = 0; i < groupWindowOrder.size(); i++) {
+                    if (groupWindowOrder[i] == seedWin) {
+                        groupCurrentIndex = i;
+                        break;
+                    }
+                }
+            }
+            if (appIcon.isNull() && !groupWindowOrder.isEmpty())
+                appIcon = Util::getCachedIcon(appPath, groupWindowOrder.first());
         }
 
         if (groupWindowOrder.size() <= 1) return; // 该应用只有一个窗口，无需切换
@@ -131,8 +141,12 @@ void Widget::keyPressEvent(QKeyEvent* event) {
         groupCurrentIndex = shiftPressed ? (groupCurrentIndex - 1 + N) % N
                                          : (groupCurrentIndex + 1) % N;
 
-        // 显示浮窗，松开 Alt 后再执行切换
-        showGroupSwitcherOverlay();
+        // 显示浮窗（首次）或仅更新选中项；松开 Alt 后再执行切换
+        if (!groupSwitcher->isVisible()) {
+            groupSwitcher->showFor(groupWindowOrder, groupCurrentIndex, appIcon, appPath);
+        } else {
+            groupSwitcher->setCurrentIndex(groupCurrentIndex);
+        }
     } else if (key == Qt::Key_Up || key == Qt::Key_Down) {
         if (auto item = lw->currentItem()) {
             auto center = lw->visualItemRect(item).center();
@@ -175,7 +189,7 @@ void Widget::showLabelForItem(QListWidgetItem* item, QString text) {
     ui->label->adjustSize();
 
     auto itemRect = lw->visualItemRect(item);
-    auto center = itemRect.center() + QPoint(0, itemRect.height() / 2 + ListWidgetMargin.bottom() / 2);
+    auto center = itemRect.center() + QPoint(0, itemRect.height() / 2 + ListWidgetMargin.bottom() / 2 + m_appStyle.labelTopGap);
     center = lw->mapTo(this, center);
     auto labelRect = ui->label->rect();
     labelRect.moveCenter(center);
@@ -187,100 +201,80 @@ void Widget::showLabelForItem(QListWidgetItem* item, QString text) {
     ui->label->move(labelRect.topLeft());
 }
 
-void Widget::setupLabelFont() {
-    static auto reloadLabelFontCfg = [this] {
-        const QStringList Fonts = {"Microsoft YaHei UI", "Microsoft YaHei", "Consolas"}; // fallback
+void Widget::reloadAppStyle() {
+    m_appStyle = cfg.loadAppStyle();
+
+    // ListWidget 图标尺寸 / 网格尺寸（gridSize = iconSize + iconPadding）
+    lw->setIconSize({m_appStyle.iconSize, m_appStyle.iconSize});
+    const int gw = m_appStyle.iconSize + m_appStyle.iconPadding.left() + m_appStyle.iconPadding.right();
+    const int gh = m_appStyle.iconSize + m_appStyle.iconPadding.top() + m_appStyle.iconPadding.bottom();
+    lw->setGridSize({gw, gh});
+    lw->setFixedHeight(gh);
+
+    // 应用到 delegate（颜色、圆角、Badge、icon padding）
+    if (itemDelegate) itemDelegate->applyStyle(m_appStyle);
+
+    // 应用到底部描述 Label：字体 + 颜色
+    {
+        const QStringList Fallbacks = {"Microsoft YaHei UI", "Microsoft YaHei", "Consolas"};
         auto labelFont = ui->label->font();
-        labelFont.setPointSize(cfg.get("label/font_size", 10).toInt());
-        auto defaultFF = QStringList{cfg.get("label/font_family", Fonts[0]).toString()};
-        labelFont.setFamilies(defaultFF << Fonts.mid(1));
+        labelFont.setPointSize(m_appStyle.labelFontSize);
+        QStringList families{m_appStyle.labelFontFamily};
+        for (const auto& f: Fallbacks)
+            if (f != m_appStyle.labelFontFamily) families << f;
+        labelFont.setFamilies(families);
         ui->label->setFont(labelFont);
-        qDebug() << labelFont.families();
+        ui->label->setStyleSheet(QString("color: %1;").arg(m_appStyle.labelColor.name(QColor::HexArgb)));
+        qDebug() << "Label families:" << labelFont.families();
         qDebug() << "Label Actual Font:" << QFontInfo(labelFont).family();
-    };
-    reloadLabelFontCfg();
-
-    // auto reload
-    connect(&cfg, &ConfigManager::configEdited, this, [] {
-        reloadLabelFontCfg();
-    });
-}
-
-void Widget::restoreDefaultListWidgetLayout() {
-    itemDelegate->setGroupSwitcherMode(false);
-    lw->setGridSize({80, 80});
-    lw->setFixedHeight(lw->gridSize().height());
-}
-
-void Widget::syncGroupWindowLabels(const QString& exePath) {
-    if (exePath.isEmpty()) return;
-
-    const auto windows = Util::listValidWindows(exePath); // 用首次扫描到的顺序固定命名，避免随活跃顺序跳动
-    auto& labelMap = groupWindowLabels[exePath];
-    auto& nextLabel = groupWindowNextLabel[exePath];
-    if (nextLabel < 1)
-        nextLabel = 1;
-
-    const QSet<HWND> activeWindows(windows.begin(), windows.end());
-    for (auto it = labelMap.begin(); it != labelMap.end();) {
-        if (activeWindows.contains(it.key()))
-            ++it;
-        else
-            it = labelMap.erase(it);
     }
 
-    for (HWND hwnd: windows) {
-        if (!labelMap.contains(hwnd))
-            labelMap.insert(hwnd, nextLabel++);
+    // 已有条目时（来自 prepareListWidget 预热），同步条目尺寸并触发重排
+    if (lw->count() > 0) {
+        for (int i = 0; i < lw->count(); i++)
+            lw->item(i)->setSizeHint(lw->gridSize());
+        // 已显示状态：重新构建并居中（rare：仅 cfg 编辑期间发生）
+        if (this->isVisible()) prepareListWidget();
     }
-}
 
-QString Widget::groupWindowLabel(const QString& exePath, HWND hwnd) const {
-    if (!hwnd) return {};
-
-    const auto labelIndex = groupWindowLabels.value(exePath).value(hwnd);
-    return labelIndex > 0 ? QString("窗口 %1").arg(labelIndex) : QString();
+    if (lw->viewport()) lw->viewport()->update();
+    update(); // 触发 paintEvent 用最新的 backgroundColor
 }
 
 void Widget::keyReleaseEvent(QKeyEvent* event) {
     if (event->key() == Qt::Key_Alt) {
-        if (this->isVisible()) {
-            if (isGroupSwitcherMode) {
-                // Alt+` 组内切换模式：直接切换到当前选中行对应的窗口
-                if (auto item = lw->currentItem()) {
-                    const auto hwndValue = item->data(GroupWindowHandleRole).toULongLong();
-                    auto hwnd = reinterpret_cast<HWND>(static_cast<quintptr>(hwndValue));
-                    if (hwnd) {
-                        Util::switchToWindow(hwnd);
-                        qInfo() << "(Alt+`)Switch to" << Util::getWindowTitle(hwnd);
+        if (groupSwitcher && groupSwitcher->isVisible()) {
+            // Alt+` 组内切换：切换到当前选中的窗口
+            // 注：groupSwitcher 不抢焦点，本进程当前无前台窗口，必须使用 force=true
+            // 跳过 Windows 的 focus-stealing prevention（对多进程 Explorer 之类的跨进程激活尤其重要）
+            if (HWND hwnd = groupSwitcher->currentHwnd()) {
+                Util::switchToWindow(hwnd, true);
+                qInfo() << "(Alt+`)Switch to" << Util::getWindowTitle(hwnd);
+            }
+            groupSwitcher->hide();
+        } else if (this->isVisible()) {
+            // Alt+Tab 模式：切换到该应用组最后活跃的窗口
+            if (auto item = lw->currentItem()) {
+                if (auto group = item->data(WindowGroupRole).value<WindowGroup>(); !group.windows.empty()) {
+                    WindowInfo targetWin = group.windows.at(0); // TODO 需要排序（lastActiveWindow 被关闭情况下）
+                    const auto lastActive = getLastActiveGroupWindow(group.exePath).first;
+                    for (auto& info: group.windows) {
+                        if (info.hwnd == lastActive) {
+                            targetWin = info;
+                            break;
+                        }
                     }
-                }
-            } else {
-                // Alt+Tab 模式：原有逻辑，切换到该应用组最后活跃的窗口
-                if (auto item = lw->currentItem()) {
-                    if (auto group = item->data(WindowGroupRole).value<WindowGroup>(); !group.windows.empty()) {
-                        WindowInfo targetWin = group.windows.at(0); // TODO 需要排序（lastActiveWindow 被关闭情况下）
-                        const auto lastActive = getLastActiveGroupWindow(group.exePath).first;
-                        for (auto& info: group.windows) {
-                            if (info.hwnd == lastActive) {
-                                targetWin = info;
-                                break;
-                            }
-                        }
-                        if (targetWin.hwnd) {
-                            Util::switchToWindow(targetWin.hwnd);
-                            qInfo() << "Switch to" << targetWin << group.exePath;
-                        }
+                    if (targetWin.hwnd) {
+                        Util::switchToWindow(targetWin.hwnd);
+                        qInfo() << "Switch to" << targetWin << group.exePath;
                     }
                 }
             }
             hide(); //! must hide after active target window, or focus may fallback to prev foreground window (like 网易云音乐)
         }
-        // 无论浮窗是否可见，都清理状态并恢复普通模式
+        // 清理 Alt+` 状态
         groupWindowOrder.clear();
         groupCurrentIndex = 0;
-        isGroupSwitcherMode = false;
-        restoreDefaultListWidgetLayout();
     }
     QWidget::keyReleaseEvent(event);
 }
@@ -289,7 +283,7 @@ void Widget::paintEvent(QPaintEvent*) { //不绘制会导致鼠标穿透背景
     QPainter painter(this);
     painter.setRenderHint(QPainter::Antialiasing);
     painter.setPen(Qt::NoPen); //取消边框//pen决定边框颜色
-    painter.setBrush(QColor(25, 25, 25, 100));
+    painter.setBrush(m_appStyle.backgroundColor);
     painter.drawRect(rect());
 }
 
@@ -379,7 +373,10 @@ bool Widget::prepareListWidget() {
         // move to scrren center
         qDebug() << "Screen:" << screen->name();
         auto lwRect = lw->rect();
-        auto thisRect = lwRect.marginsAdded(ListWidgetMargin);
+        auto margins = ListWidgetMargin;
+        // 为底部描述 Label 预留额外间距：上间距（label 距图标）+ 下间距（label 距浮窗底）
+        margins.setBottom(margins.bottom() + m_appStyle.labelTopGap + m_appStyle.labelBottomGap);
+        auto thisRect = lwRect.marginsAdded(margins);
         thisRect.moveCenter(screen->geometry().center());
 
         //region Fixed in Qt6, see commit [b927ee4b]
@@ -429,81 +426,15 @@ bool Widget::prepareListWidget() {
     return true;
 }
 
-/// 显示 Alt+` 组内切换浮窗，列出同应用的所有窗口
-/// 每格：上方"窗口 N"，中间图标，下方窗口标题
-void Widget::showGroupSwitcherOverlay() {
-    isGroupSwitcherMode = true;
-
-    // 仅在首次显示或窗口数量变化时重建列表
-    if (!this->isVisible() || lw->count() != groupWindowOrder.size()) {
-        lw->clear();
-        if (groupWindowOrder.isEmpty()) return;
-
-        // 启用组切换模式：图标格高度增加以容纳上下文字
-        // 布局：更宽的格子 + 上下文字，避免图标过挤且标题被过早截断
-        constexpr int GroupGridW = 124;
-        constexpr int GroupGridH = 110;
-        itemDelegate->setGroupSwitcherMode(true);
-        lw->setGridSize({GroupGridW, GroupGridH});
-        lw->setFixedHeight(GroupGridH);
-
-        auto firstHwnd = groupWindowOrder.first();
-        auto appPath = Util::getWindowProcessPath(firstHwnd);
-        auto appIcon = Util::getCachedIcon(appPath, firstHwnd);
-
-        for (int i = 0; i < groupWindowOrder.size(); i++) {
-            HWND hwnd = groupWindowOrder[i];
-            auto title = Util::getWindowTitle(hwnd);
-            // 无标题时留空（delegate 不绘制空字符串）
-
-            // 每个 item 对应一个窗口，WindowGroup 仅含单个 WindowInfo
-            WindowGroup singleGroup;
-            singleGroup.exePath = appPath;
-            singleGroup.icon = appIcon;
-            singleGroup.addWindow({title, Util::getClassName(hwnd), hwnd});
-
-            auto* item = new QListWidgetItem(appIcon, {});
-            item->setData(WindowGroupRole, QVariant::fromValue(singleGroup));
-            item->setData(GroupWindowHandleRole, static_cast<qulonglong>(reinterpret_cast<quintptr>(hwnd)));
-            auto label = groupWindowLabel(appPath, hwnd);
-            if (label.isEmpty())
-                label = QString("窗口 %1").arg(i + 1);
-            item->setData(GroupWindowLabelRole, label);
-            item->setSizeHint(lw->gridSize());
-            lw->addItem(item);
-        }
-
-        // 计算并设置几何尺寸（与 prepareListWidget 逻辑保持一致）
-        if (auto firstItem = lw->item(0)) {
-            auto firstRect = lw->visualItemRect(firstItem);
-            auto width = lw->gridSize().width() * lw->count() + (firstRect.x() - lw->frameWidth());
-            lw->setFixedWidth(width);
-
-            bool displayOnPrimary = (cfg.getDisplayMonitor() == PrimaryMonitor);
-            auto screen = displayOnPrimary ?
-                          QGuiApplication::primaryScreen() :
-                          QGuiApplication::screenAt(QCursor::pos());
-            if (!screen && !displayOnPrimary)
-                screen = QGuiApplication::primaryScreen();
-            if (!screen) return;
-
-            auto lwRect = lw->rect();
-            auto thisRect = lwRect.marginsAdded(ListWidgetMargin);
-            thisRect.moveCenter(screen->geometry().center());
-            this->setGeometry(thisRect);
-
-            lwRect.moveCenter(this->rect().center());
-            lw->move(lwRect.topLeft());
-        }
-
-        forceShow();
-    }
-
-    // 更新高亮行（触发 currentItemChanged 信号以刷新底部标签文字）
-    lw->setCurrentRow(groupCurrentIndex);
-}
+/// 显示 Alt+` 组内切换浮窗（已迁移至 GroupSwitcherWidget；此处保留空注释占位）
 
 bool Widget::requestShow() { // TODO 当前台是开始菜单（Win）时，会导致显示 但无法操控
+    // 模式互斥：若 Alt+` 浮窗在显示中，先隐藏并清理状态以便切换到 Alt+Tab 模式
+    if (groupSwitcher && groupSwitcher->isVisible()) {
+        groupSwitcher->hide();
+        groupWindowOrder.clear();
+        groupCurrentIndex = 0;
+    }
     return prepareListWidget() && forceShow();
 }
 

--- a/src/widget.cpp
+++ b/src/widget.cpp
@@ -51,11 +51,23 @@ Widget::Widget(QWidget* parent) : QWidget(parent), ui(new Ui::Widget) {
     // 本来为了去除图标选中变色样式，可以对Icon手动addPixmap(..., QIcon::Selected) or (& ~Qt::ItemIsSelectable)
     // 但是采用delegate后，就没必要了
     // will not take ownership of delegate
-    lw->setItemDelegate(new IconOnlyDelegate(lw));
+    itemDelegate = new IconOnlyDelegate(lw);
+    lw->setItemDelegate(itemDelegate);
     lw->installEventFilter(this);
 
     connect(lw, &QListWidget::currentItemChanged, this, [this](QListWidgetItem* cur, QListWidgetItem*) {
-        if (cur) showLabelForItem(cur);
+        if (!cur) return;
+        if (isGroupSwitcherMode) {
+            // 组内切换模式：显示具体窗口标题
+            int row = lw->row(cur);
+            if (row >= 0 && row < groupWindowOrder.size()) {
+                auto title = Util::getWindowTitle(groupWindowOrder[row]);
+                if (title.isEmpty()) title = QString("窗口 %1").arg(row + 1);
+                showLabelForItem(cur, title);
+            }
+        } else {
+            showLabelForItem(cur);
+        }
     });
 
     connect(qApp, &QApplication::focusWindowChanged, this, [this](QWindow* focusWindow) {
@@ -89,21 +101,37 @@ void Widget::keyPressEvent(QKeyEvent* event) {
         auto index = (i - (2 * isShiftPressed - 1) + lw->count()) % lw->count();
         lw->setCurrentRow(index);
     } else if (key == Qt::Key_QuoteLeft && (modifiers & Qt::AltModifier)) { // Alt + `, 在前台窗口同组窗口内切换
-        if (this->isVisible() && !this->isMinimized()) {
-            // isVisible() == true if minimized
-            // 不使用`isForeground()`，即使`bringWindowToTop`(without active)，少数窗口也可能抢夺焦点，如`CAJViewer`
+        // 如果当前显示的是 Alt+Tab 列表（非组内切换模式），则直接隐藏
+        if (this->isVisible() && !this->isMinimized() && !isGroupSwitcherMode) {
             hide();
             return;
         }
+
         auto foreWin = GetForegroundWindow();
+        bool shiftPressed = modifiers & Qt::ShiftModifier;
+
+        // 首次按下：构建同组窗口列表，并定位当前窗口在列表中的索引
         if (groupWindowOrder.isEmpty()) {
             auto targetExe = Util::getWindowProcessPath(foreWin);
             groupWindowOrder = buildGroupWindowOrder(targetExe);
+            groupCurrentIndex = 0;
+            for (int i = 0; i < groupWindowOrder.size(); i++) {
+                if (groupWindowOrder[i] == foreWin) {
+                    groupCurrentIndex = i;
+                    break;
+                }
+            }
         }
-        if (auto nextWin = rotateWindowInGroup(groupWindowOrder, foreWin, !(modifiers & Qt::ShiftModifier))) {
-            Util::switchToWindow(nextWin, true);
-            qInfo() << "(Alt+`)Switch to" << Util::getWindowTitle(nextWin) << Util::getClassName(nextWin);
-        }
+
+        if (groupWindowOrder.size() <= 1) return; // 该应用只有一个窗口，无需切换
+
+        // 向前或向后轮换选中索引
+        int N = groupWindowOrder.size();
+        groupCurrentIndex = shiftPressed ? (groupCurrentIndex - 1 + N) % N
+                                         : (groupCurrentIndex + 1) % N;
+
+        // 显示浮窗，松开 Alt 后再执行切换
+        showGroupSwitcherOverlay();
     } else if (key == Qt::Key_Up || key == Qt::Key_Down) {
         if (auto item = lw->currentItem()) {
             auto center = lw->visualItemRect(item).center();
@@ -179,27 +207,46 @@ void Widget::setupLabelFont() {
 
 void Widget::keyReleaseEvent(QKeyEvent* event) {
     if (event->key() == Qt::Key_Alt) {
-        groupWindowOrder.clear(); // for Alt + `
         if (this->isVisible()) {
-            // active selected window
-            if (auto item = lw->currentItem()) {
-                if (auto group = item->data(Qt::UserRole).value<WindowGroup>(); !group.windows.empty()) {
-                    WindowInfo targetWin = group.windows.at(0); // TODO 需要排序（lastActiveWindow 被关闭情况下）
-                    const auto lastActive = getLastActiveGroupWindow(group.exePath).first;
-                    for (auto& info: group.windows) {
-                        if (info.hwnd == lastActive) {
-                            targetWin = info;
-                            break;
-                        }
+            if (isGroupSwitcherMode) {
+                // Alt+` 组内切换模式：直接切换到当前选中行对应的窗口
+                int row = lw->currentRow();
+                if (row >= 0 && row < groupWindowOrder.size()) {
+                    HWND hwnd = groupWindowOrder[row];
+                    if (hwnd) {
+                        Util::switchToWindow(hwnd);
+                        qInfo() << "(Alt+`)Switch to" << Util::getWindowTitle(hwnd);
                     }
-                    if (targetWin.hwnd) {
-                        Util::switchToWindow(targetWin.hwnd);
-                        qInfo() << "Switch to" << targetWin << group.exePath;
+                }
+            } else {
+                // Alt+Tab 模式：原有逻辑，切换到该应用组最后活跃的窗口
+                if (auto item = lw->currentItem()) {
+                    if (auto group = item->data(Qt::UserRole).value<WindowGroup>(); !group.windows.empty()) {
+                        WindowInfo targetWin = group.windows.at(0); // TODO 需要排序（lastActiveWindow 被关闭情况下）
+                        const auto lastActive = getLastActiveGroupWindow(group.exePath).first;
+                        for (auto& info: group.windows) {
+                            if (info.hwnd == lastActive) {
+                                targetWin = info;
+                                break;
+                            }
+                        }
+                        if (targetWin.hwnd) {
+                            Util::switchToWindow(targetWin.hwnd);
+                            qInfo() << "Switch to" << targetWin << group.exePath;
+                        }
                     }
                 }
             }
             hide(); //! must hide after active target window, or focus may fallback to prev foreground window (like 网易云音乐)
         }
+        // 无论浮窗是否可见，都清理状态并恢复普通模式
+        groupWindowOrder.clear();
+        groupCurrentIndex = 0;
+        isGroupSwitcherMode = false;
+        // 恢复 Alt+Tab 模式的格子尺寸和委托模式
+        itemDelegate->setGroupSwitcherMode(false);
+        lw->setGridSize({80, 80});
+        lw->setFixedHeight(80);
     }
     QWidget::keyReleaseEvent(event);
 }
@@ -346,6 +393,74 @@ bool Widget::prepareListWidget() {
     }
 
     return true;
+}
+
+/// 显示 Alt+` 组内切换浮窗，列出同应用的所有窗口
+/// 每格：上方"窗口 N"，中间图标，下方窗口标题
+void Widget::showGroupSwitcherOverlay() {
+    isGroupSwitcherMode = true;
+
+    // 仅在首次显示或窗口数量变化时重建列表
+    if (!this->isVisible() || lw->count() != groupWindowOrder.size()) {
+        lw->clear();
+        if (groupWindowOrder.isEmpty()) return;
+
+        // 启用组切换模式：图标格高度增加以容纳上下文字
+        // 布局：18px"窗口 N" + 64px 图标 + 16px 标题 + 12px 边距 = 110px
+        constexpr int GroupGridH = 110;
+        itemDelegate->setGroupSwitcherMode(true);
+        lw->setGridSize({80, GroupGridH});
+        lw->setFixedHeight(GroupGridH);
+
+        auto firstHwnd = groupWindowOrder.first();
+        auto appPath = Util::getWindowProcessPath(firstHwnd);
+        auto appIcon = Util::getCachedIcon(appPath, firstHwnd);
+
+        for (int i = 0; i < groupWindowOrder.size(); i++) {
+            HWND hwnd = groupWindowOrder[i];
+            auto title = Util::getWindowTitle(hwnd);
+            // 无标题时留空（delegate 不绘制空字符串）
+
+            // 每个 item 对应一个窗口，WindowGroup 仅含单个 WindowInfo
+            WindowGroup singleGroup;
+            singleGroup.exePath = appPath;
+            singleGroup.icon = appIcon;
+            singleGroup.addWindow({title, Util::getClassName(hwnd), hwnd});
+
+            auto* item = new QListWidgetItem(appIcon, {});
+            item->setData(Qt::UserRole, QVariant::fromValue(singleGroup));
+            item->setSizeHint(lw->gridSize());
+            lw->addItem(item);
+        }
+
+        // 计算并设置几何尺寸（与 prepareListWidget 逻辑保持一致）
+        if (auto firstItem = lw->item(0)) {
+            auto firstRect = lw->visualItemRect(firstItem);
+            auto width = lw->gridSize().width() * lw->count() + (firstRect.x() - lw->frameWidth());
+            lw->setFixedWidth(width);
+
+            bool displayOnPrimary = (cfg.getDisplayMonitor() == PrimaryMonitor);
+            auto screen = displayOnPrimary ?
+                          QGuiApplication::primaryScreen() :
+                          QGuiApplication::screenAt(QCursor::pos());
+            if (!screen && !displayOnPrimary)
+                screen = QGuiApplication::primaryScreen();
+            if (!screen) return;
+
+            auto lwRect = lw->rect();
+            auto thisRect = lwRect.marginsAdded(ListWidgetMargin);
+            thisRect.moveCenter(screen->geometry().center());
+            this->setGeometry(thisRect);
+
+            lwRect.moveCenter(this->rect().center());
+            lw->move(lwRect.topLeft());
+        }
+
+        forceShow();
+    }
+
+    // 更新高亮行（触发 currentItemChanged 信号以刷新底部标签文字）
+    lw->setCurrentRow(groupCurrentIndex);
 }
 
 bool Widget::requestShow() { // TODO 当前台是开始菜单（Win）时，会导致显示 但无法操控


### PR DESCRIPTION
## Summary
- Show a frosted-glass overlay when pressing `Alt+`` ` (same visual style as `Alt+Tab`)
- Each item displays **"窗口 N"** above the icon and the **window title** below it
- Window switching is deferred until `Alt` is released (instead of switching immediately)
## Changes
- **`IconOnlyDelegate`**: added group switcher mode — draws number label above icon and title below
- **`Widget`**: added `showGroupSwitcherOverlay()` with a taller grid (110px) to accommodate text labels; stores `itemDelegate` pointer to toggle modes at runtime
- **`keyPressEvent`** (`Alt+`` `): tracks `groupCurrentIndex`, shows overlay instead of switching immediately; `Alt+Shift+`` ` navigates in reverse
- **`keyReleaseEvent`**: switches to the highlighted window on Alt release, then resets all state
## Test plan
- [ ] Open multiple windows of the same app (e.g. VS Code, Notepad)
- [ ] Hold `Alt` and press `` ` `` repeatedly — overlay should appear and cycle through windows
- [ ] Press `Alt+Shift+`` ` to cycle in reverse
- [ ] Release `Alt` — should switch to the highlighted window
- [ ] Verify `Alt+Tab` still works normally after using `Alt+`` `